### PR TITLE
Add user group event relationships to db schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,11 +11,19 @@ datasource db {
   relationMode = "prisma"
 }
 
+enum Role {
+  ADMIN
+  USER
+  APPLICANT
+}
+
 model User {
   id       String    @id @default(uuid())
   email    String    @unique
   name     String
   password Password?
+  groups   Group[]
+  events   Event[]
 }
 
 model Password {
@@ -25,22 +33,30 @@ model Password {
   hash   String
 }
 
-// Originally thought it was going to be a many-to-many relationship
-// Thought about it again and decided it was one-to-many
-// Andre - looking forward to your feedback!
 model Group {
-  id          String @id @default(uuid())
+  id          String  @id @default(uuid())
   name        String
   description String
   events      Event[]
+  users       User[]
+}
+
+model User_Group {
+  userId  String
+  groupId String
+  role    Role
+
+  @@id([userId, groupId])
 }
 
 model Event {
-  id          String @id @default(uuid())
+  id          String   @id @default(uuid())
   name        String
   date        DateTime
   description String
-  group       Group @relation(fields: [groupId], references: [id])
-  groupId     String @unique
-}
+  group       Group    @relation(fields: [groupId], references: [id])
+  groupId     String
+  users       User[]
 
+  @@index([groupId], name: "groupId")
+}


### PR DESCRIPTION
Issue: N/A

## Summary (1-2 sentences)

This PR adds relationship models for user-group and user-event relationships to the `prisma.schema` file.

## Details (reason and description of the changes)

We have the following product requirements:

- A user should be able to create/manage groups
- A user should be able to create/edit events
- A user should be able to join groups
- A user should be able to RSVP/join events

This can be translated into relationships between the user, group, and event database tables.

### Many-to-many user group relationship:

- A user can have many groups.
- A group can have many users.
- A user in a group has a role, like admin or member.

### Many-to-many user event relationship:

- A user can RSVP to many events.
- An event can have many users.

### Implementation details (how was this change implemented?) (optional)

![Screenshot 2023-07-24 at 7 30 04 PM](https://github.com/social-plan-it/plan-it-social-web/assets/15163028/d3bfa586-ed88-41a2-ae13-5cf55ce840ba)

