### PR TITLE
Create DashboardHeader component, update groups_.new route to use it

### DIFF
--- a/app/components/ui/containers.tsx
+++ b/app/components/ui/containers.tsx
@@ -1,3 +1,7 @@
 export function Card({ children }: { children: React.ReactNode }) {
   return <section className="w-full bg-white shadow-lg rounded-lg px-2 py-6 lg:p-16">{children}</section>;
 }
+
+export function DashboardHeader({ children }: { children: React.ReactNode }) {
+  return <h1 className="text-black font-bold text-4xl">{children}</h1>;
+}

--- a/app/routes/groups_.new.tsx
+++ b/app/routes/groups_.new.tsx
@@ -1,11 +1,11 @@
-import { Card } from '~/components/ui/containers';
+import { Card, DashboardHeader } from '~/components/ui/containers';
 
 export default function GroupNew() {
   return (
     <div className="grow py-20 lg:py-40 bg-secondary w-full flex flex-col items-center justify-center">
       <div className="flex w-full items-center justify-center flex-col">
         <div className="max-w-[900px] w-full flex flex-col gap-3">
-          <h1 className="text-black font-bold text-4xl">Create New Group</h1>
+          <DashboardHeader>Create New Group</DashboardHeader>
           <h2 className="text-black font-bold text-2xl">Your Community Starts Here</h2>
           <Card>
             <div className="flex pt-4">


### PR DESCRIPTION
 <!-- 
Please consider splitting up big PRs (more than 10-15 files) into several small ones for easier reviews
-->

Issue: #42 

## Summary (1-2 sentences)

This PR simplifies dashboard development by abstracting styling for h1 header components. The new component is applied to the `groups/new` page.

## Details (reason and description of the changes)

Having a reusable component will make it easier to update dashboard header styles if they need to change in the future. We can now update in one location to update multiple pages. The style settings are the closest available default tailwindcss styles that match the figma design doc.

### Implementation details (how was this change implemented?) 

This change is dependent on @andrelandgraf's Implement loading indications (login, signup), improve layout (groups/new) PR.

 <!--
Checklist before requesting a review:

- [y] I have performed a self-review of my code
- [na] I have commented my code, particularly in hard-to-understand areas
- [y] My code does not generate any new warnings or errors
- [na] New and existing unit tests pass locally with my changes (if relevant)
- [na] Screenshots and recordings for UI changes

-->
