### PR TITLE
Reflect the user's logged in state in top nav

### DIFF
--- a/app/components/layout/top-nav.tsx
+++ b/app/components/layout/top-nav.tsx
@@ -87,3 +87,16 @@ export function TopNav() {
     </nav>
   );
 }
+
+function LogoutButton({ className }: { className?: string }) {
+  const navigation = useNavigation();
+  const isPending = navigation.state === 'submitting' || navigation.state === 'loading';
+
+  return (
+    <Form method="post" action="/logout">
+      <button disabled={isPending} className={className}>
+        {isPending ? 'Logging out...' : 'Log Out'}
+      </button>
+    </Form>
+  );
+}

--- a/app/components/layout/top-nav.tsx
+++ b/app/components/layout/top-nav.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
-import { Link } from '@remix-run/react';
+import { Form, Link, useNavigation } from '@remix-run/react';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 
 export function TopNav() {
+  const currentUser = useCurrentUser();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const toggleMenu = () => {
@@ -34,16 +36,20 @@ export function TopNav() {
                 <li className="ml-4 text-2xl py-1 hover:py-0">Groups</li>
               </Link>
             </ul>
-            <ul className="flex">
-              <Link to="/login">
-                <li className="text-2xl py-1 hover:py-0">Log in</li>
-              </Link>
-              <Link to="/signup">
-                <li className="ml-4 bg-white text-primary rounded-full px-2 py-1 text-2xl hover:bg-primary hover:text-secondary hover:border-white hover:border-solid hover:py-0">
-                  Sign up
-                </li>
-              </Link>
-            </ul>
+            {currentUser ? (
+              <LogoutButton className="text-2xl py-1 hover:py-0" />
+            ) : (
+              <ul className="flex">
+                <Link to="/login">
+                  <li className="text-2xl py-1 hover:py-0">Log in</li>
+                </Link>
+                <Link to="/signup">
+                  <li className="ml-4 bg-white text-primary rounded-full px-2 py-1 text-2xl hover:bg-primary hover:text-secondary hover:border-white hover:border-solid hover:py-0">
+                    Sign up
+                  </li>
+                </Link>
+              </ul>
+            )}
           </div>
         </div>
         <button className="text-white block md:hidden" onClick={toggleMenu}>
@@ -76,12 +82,18 @@ export function TopNav() {
           <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/groups">
             Groups
           </Link>
-          <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/signin">
-            Sign in
-          </Link>
-          <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/signup">
-            Sign up
-          </Link>
+          {currentUser ? (
+            <LogoutButton className="w-full text-left text-white py-2 px-4 hover:bg-gray-700" />
+          ) : (
+            <>
+              <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/signin">
+                Sign in
+              </Link>
+              <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/signup">
+                Sign up
+              </Link>
+            </>
+          )}
         </div>
       )}
     </nav>

--- a/app/components/layout/top-nav.tsx
+++ b/app/components/layout/top-nav.tsx
@@ -86,8 +86,8 @@ export function TopNav() {
             <LogoutButton className="w-full text-left text-white py-2 px-4 hover:bg-gray-700" />
           ) : (
             <>
-              <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/signin">
-                Sign in
+              <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/login">
+                Log in
               </Link>
               <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/signup">
                 Sign up

--- a/app/components/layout/top-nav.tsx
+++ b/app/components/layout/top-nav.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Link } from '@remix-run/react';
 
 export function TopNav() {

--- a/app/components/layout/top-nav.tsx
+++ b/app/components/layout/top-nav.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import {Link} from "@remix-run/react"
+import { Link } from '@remix-run/react';
 
 export function TopNav() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -12,26 +12,41 @@ export function TopNav() {
     <nav className="bg-gray-800 p-4">
       <div className="flex justify-start items-center max-w-screen-2xl mx-auto">
         <div className="text-white text-xl font-semibold flex justify-between items-center py-4 w-full">
-          <Link to="/"><img  className="w-1/3" src="https://res.cloudinary.com/dxctpvd8v/image/upload/v1683267003/SocialPlanIt/SocialPlan-it-logo-Horizontal_xwm3xt.png" alt="Social Plan It horizontal logo" /></Link>
-          <div className="hidden md:flex justify-between w-3/4 py-4" >
-          <ul className='flex'>
-            <Link to="/"><li className='text-2xl py-1 hover:py-0'>Home</li></Link>
-            <Link to="/about-us"><li className='ml-4 text-2xl py-1 hover:py-0'>About</li></Link>
-            <Link to="/events"><li className='ml-4 text-2xl py-1 hover:py-0'>Events</li></Link>
-            <Link to="/groups"><li className='ml-4 text-2xl py-1 hover:py-0'>Groups</li></Link>
-          </ul>
-          <ul className='flex'>
-            <Link to="/login"><li className='text-2xl py-1 hover:py-0'>Log in</li></Link>
-            <Link to="/signup"><li className='ml-4 bg-white text-primary rounded-full px-2 py-1 text-2xl hover:bg-primary hover:text-secondary hover:border-white hover:border-solid hover:py-0' >Sign up</li></Link>
-            
-          </ul>
+          <Link to="/">
+            <img
+              className="w-1/3"
+              src="https://res.cloudinary.com/dxctpvd8v/image/upload/v1683267003/SocialPlanIt/SocialPlan-it-logo-Horizontal_xwm3xt.png"
+              alt="Social Plan It horizontal logo"
+            />
+          </Link>
+          <div className="hidden md:flex justify-between w-3/4 py-4">
+            <ul className="flex">
+              <Link to="/">
+                <li className="text-2xl py-1 hover:py-0">Home</li>
+              </Link>
+              <Link to="/about-us">
+                <li className="ml-4 text-2xl py-1 hover:py-0">About</li>
+              </Link>
+              <Link to="/events">
+                <li className="ml-4 text-2xl py-1 hover:py-0">Events</li>
+              </Link>
+              <Link to="/groups">
+                <li className="ml-4 text-2xl py-1 hover:py-0">Groups</li>
+              </Link>
+            </ul>
+            <ul className="flex">
+              <Link to="/login">
+                <li className="text-2xl py-1 hover:py-0">Log in</li>
+              </Link>
+              <Link to="/signup">
+                <li className="ml-4 bg-white text-primary rounded-full px-2 py-1 text-2xl hover:bg-primary hover:text-secondary hover:border-white hover:border-solid hover:py-0">
+                  Sign up
+                </li>
+              </Link>
+            </ul>
           </div>
-          
         </div>
-        <button
-          className="text-white block md:hidden"
-          onClick={toggleMenu}
-        >
+        <button className="text-white block md:hidden" onClick={toggleMenu}>
           <svg
             className="w-6 h-6"
             fill="none"
@@ -40,63 +55,35 @@ export function TopNav() {
             xmlns="http://www.w3.org/2000/svg"
           >
             {isMenuOpen ? (
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             ) : (
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 6h16M4 12h16M4 18h16"
-              />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
             )}
           </svg>
         </button>
       </div>
       {isMenuOpen && (
         <div className="mt-4">
-          <Link
-            className="block text-white py-2 px-4 hover:bg-gray-700"
-            to="/"
-          >
+          <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/">
             Home
           </Link>
-          <Link
-            className="block text-white py-2 px-4 hover:bg-gray-700"
-            to="/about-us"
-          >
+          <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/about-us">
             About
           </Link>
-          <Link
-            className="block text-white py-2 px-4 hover:bg-gray-700"
-            to="/events"
-          >
+          <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/events">
             Events
           </Link>
-          <Link
-            className="block text-white py-2 px-4 hover:bg-gray-700"
-            to="/groups"
-          >
+          <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/groups">
             Groups
           </Link>
-          <Link
-            className="block text-white py-2 px-4 hover:bg-gray-700"
-            to="/signin"
-          >
+          <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/signin">
             Sign in
           </Link>
-          <Link
-            className="block text-white py-2 px-4 hover:bg-gray-700"
-            to="/signup"
-          >
+          <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/signup">
             Sign up
           </Link>
         </div>
       )}
     </nav>
   );
-};
+}


### PR DESCRIPTION
Issue: #26

## Summary
Reflect the user's logged in state in the top navigation bar.

## Details

### Re-implement the reflection of the user's logged in state in the top nav, previously implemented in PR #39 and regressed in PR #53:

- When the user is NOT logged in, the top nav shows links to `/login` and `/signup`.
- When the user is logged in, the top nav shows a button to `/logout`.

### Fix related bug:

- On mobile view, change "Sign in" to "Log in" and `/signin` to `/login`

### Alternative implementations

The logout button was implemented using a `POST` request via form action rather than a `GET` request via a link. This is because Remix will not re-call our `loader` functions when we do not perform an `action` and this could potentially lead to stale data (i.e. the UI might still show the user as logged in when the user has already logged out).

## Screenshots/Recordings

https://github.com/social-plan-it/plan-it-social-web/assets/63323230/63fcb0ba-55bb-43dd-bcc1-3df1e4ecfcf4

https://github.com/social-plan-it/plan-it-social-web/assets/63323230/9b289b84-7db3-43d4-9a78-ea430052f7bf

 <!--
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My code does not generate any new warnings or errors
- [x] New and existing unit tests pass locally with my changes (if relevant)
- [x] Screenshots and recordings for UI changes
-->
