### PR TITLE
Fix: UI shows logged in users logging out when navigating

### DIFF
--- a/app/components/layout/top-nav.tsx
+++ b/app/components/layout/top-nav.tsx
@@ -102,10 +102,12 @@ export function TopNav() {
 
 function LogoutButton({ className }: { className?: string }) {
   const navigation = useNavigation();
-  const isPending = navigation.state === 'submitting' || navigation.state === 'loading';
+  const formAction = '/logout';
+  const isPending =
+    navigation.formAction === formAction && (navigation.state === 'submitting' || navigation.state === 'loading');
 
   return (
-    <Form method="post" action="/logout">
+    <Form method="post" action={formAction}>
       <button disabled={isPending} className={className}>
         {isPending ? 'Logging out...' : 'Log Out'}
       </button>


### PR DESCRIPTION
Issue: #56 

## Summary

Fixes #56, where the UI shows logged in users logging out when navigating.

## Details

The log out button currently relies on `navigation.state === 'submitting' || navigation.state === 'loading'` to determine when to show pending UI to the user. However, any navigation that calls loader functions, or submissions to other forms, will also trigger this pending UI. By checking which form action triggered the navigation (i.e. `useNavigation().formAction === '/logout'`), we can show our pending UI only if the navigation was caused by a specific form action.

### Alternative implementations

The [`useFetcher`](https://remix.run/docs/en/1.19.3/hooks/use-fetcher) hook was considered, but in this case, since we are doing a navigation, it makes more sense and is simpler to use the [`useNavigation`](https://remix.run/docs/en/1.19.3/hooks/use-navigation) hook.

### Sources

Here is a good [video](https://www.youtube.com/watch?v=y4VLIFjFq8k&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6) where Ryan Florence goes through an example of how to show pending UI in Remix. Please note that it is a bit outdated and uses the old `useTransition` hook rather than the new `useNavigation` hook in Remix v2, but the overall concepts are still very relevant. This video is part of a [series](https://www.youtube.com/playlist?list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6) that goes over various Remix concepts including when to use `useFetcher`.

## Screenshots/Recordings

### Before fix (desktop):

https://github.com/social-plan-it/plan-it-social-web/assets/63323230/cb83e0e8-99a8-4fd1-b26a-a3e31efdb6cb

### After fix (desktop):

https://github.com/social-plan-it/plan-it-social-web/assets/63323230/149186e9-1e97-480d-86ff-d17179fdd55f

### Before fix (mobile):

https://github.com/social-plan-it/plan-it-social-web/assets/63323230/ec33a4b1-6dd2-40c4-b716-44d0bf1a9813

### After fix (mobile):

https://github.com/social-plan-it/plan-it-social-web/assets/63323230/becd788b-a503-43b2-8133-0668ca26c35c



 <!--
Checklist before requesting a review:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My code does not generate any new warnings or errors
- [ ] New and existing unit tests pass locally with my changes (if relevant)
- [ ] Screenshots and recordings for UI changes

-->
