### PR TITLE
Created hooks for getting events and groups

### DIFF
--- a/app/hooks/useEvents.ts
+++ b/app/hooks/useEvents.ts
@@ -1,0 +1,9 @@
+import type { SerializeFrom } from '@remix-run/node';
+import { useRouteLoaderData } from '@remix-run/react';
+import type { loader } from '~/root';
+
+export function useEvents() {
+  const data = useRouteLoaderData('root') as SerializeFrom<typeof loader> | undefined;
+
+  return data?.events;
+}

--- a/app/hooks/useEvents.ts
+++ b/app/hooks/useEvents.ts
@@ -4,6 +4,11 @@ import type { loader } from '~/root';
 
 export function useEvents() {
   const data = useRouteLoaderData('root') as SerializeFrom<typeof loader> | undefined;
+  const events = data?.events;
+  const deserializedEvents = events?.map((event) => ({
+    ...event,
+    date: new Date(event.date),
+  }));
 
-  return data?.events;
+  return deserializedEvents;
 }

--- a/app/hooks/useGroups.ts
+++ b/app/hooks/useGroups.ts
@@ -1,0 +1,9 @@
+import type { SerializeFrom } from '@remix-run/node';
+import { useRouteLoaderData } from '@remix-run/react';
+import type { loader } from '~/root';
+
+export function useGroups() {
+  const data = useRouteLoaderData('root') as SerializeFrom<typeof loader> | undefined;
+
+  return data?.groups;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,15 +5,21 @@ import { TopNav } from '~/components/layout/top-nav';
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from '@remix-run/react';
 import Footer from './components/layout/footer';
 import { getCurrentUser } from '~/modules/session/session.server';
+import { db } from './modules/database/db.server';
 
 export const links: LinksFunction = () => [{ rel: 'stylesheet', href: stylesheet }];
 
 export async function loader({ request }: LoaderArgs) {
+  const events = await db.event.findMany({ include: { group: true }, take: 24 });
+  const groups = await db.group.findMany({ take: 24 });
+
   return json({
     ENV: {
       PUBLIC_GOOGLE_CLIENT_ID: process.env.PUBLIC_GOOGLE_CLIENT_ID,
     },
     currentUser: await getCurrentUser(request),
+    events,
+    groups,
   });
 }
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -10,8 +10,9 @@ import { db } from './modules/database/db.server';
 export const links: LinksFunction = () => [{ rel: 'stylesheet', href: stylesheet }];
 
 export async function loader({ request }: LoaderArgs) {
-  const events = await db.event.findMany({ include: { group: true }, take: 24 });
-  const groups = await db.group.findMany({ take: 24 });
+  const eventsPromise = db.event.findMany({ include: { group: true }, take: 24 });
+  const groupsPromise = db.group.findMany({ take: 24 });
+  const [events, groups] = await Promise.all([eventsPromise, groupsPromise]);
 
   return json({
     ENV: {

--- a/app/routes/events.tsx
+++ b/app/routes/events.tsx
@@ -3,16 +3,10 @@ import { useEvents } from '~/hooks/useEvents';
 
 export default function EventsPage() {
   const events = useEvents();
-
-  const deserializedEvents = events?.map((event) => ({
-    ...event,
-    date: new Date(event.date),
-  }));
-
   return (
     <Card>
       <ul className="max-w-md space-y-1 text-gray-500 list-disc list-inside dark:text-gray-400">
-        {deserializedEvents?.map((event) => {
+        {events?.map((event) => {
           return <li key={event.id}>{event.name}</li>;
         })}
       </ul>

--- a/app/routes/events.tsx
+++ b/app/routes/events.tsx
@@ -1,0 +1,21 @@
+import { Card } from '~/components/ui/containers';
+import { useEvents } from '~/hooks/useEvents';
+
+export default function EventsPage() {
+  const events = useEvents();
+
+  const deserializedEvents = events?.map((event) => ({
+    ...event,
+    date: new Date(event.date),
+  }));
+
+  return (
+    <Card>
+      <ul className="max-w-md space-y-1 text-gray-500 list-disc list-inside dark:text-gray-400">
+        {deserializedEvents?.map((event) => {
+          return <li key={event.id}>{event.name}</li>;
+        })}
+      </ul>
+    </Card>
+  );
+}

--- a/app/routes/groups.tsx
+++ b/app/routes/groups.tsx
@@ -1,9 +1,15 @@
+import { Card } from '~/components/ui/containers';
+import { useGroups } from '~/hooks/useGroups';
+
 export default function Group() {
+  const groups = useGroups();
   return (
-    <div className="flex w-full items-center justify-center mt-20 lg:mt-40">
-      <div>
-        <h1>List of Groups</h1>
-      </div>
-    </div>
+    <Card>
+      <ul className="max-w-md space-y-1 text-gray-500 list-disc list-inside dark:text-gray-400">
+        {groups?.map((group) => {
+          return <li key={group.id}>{group.name}</li>;
+        })}
+      </ul>
+    </Card>
   );
 }


### PR DESCRIPTION
Issue: #50 

## Summary
This is the first iteration of getting data if a user logged in. This PR adds 'useEvents' and 'useGroups' hooks to simplify data usage in app routes.

## Details 
We can improve the app's performance by prefetching data and displaying it to users throughout the app.

## For a future discussion.
After checking MeetUp and Eventbrite web apps, it's decided to start showing 24 events and groups to prevent data over-fetching in the future. @tonydangblog suggested using 'orderBy' in the Prisma query to filter by the freshest events and maybe groups. It was also noted that we'll need createdAt rows in the data schemas. 

## Sources 
https://www.prisma.io/docs/concepts/components/prisma-client/pagination

## Screenshots/Recordings (if applicable)
https://github.com/social-plan-it/plan-it-social-web/assets/114109736/c3d66eb0-0312-4fb9-938f-bcbadfe37c7e

## Co-authored-by:
- Tony Dang @tonydangblog
- Elizabeth
- Sing Wong @eiffelwong1

 <!--
Checklist before requesting a review:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My code does not generate any new warnings or errors
- [ ] New and existing unit tests pass locally with my changes (if relevant)
- [ ] Screenshots and recordings for UI changes

-->
