### PR TITLE
Create reusable form input components

### DIFF
--- a/app/components/ui/containers.tsx
+++ b/app/components/ui/containers.tsx
@@ -1,3 +1,3 @@
 export function Card({ children }: { children: React.ReactNode }) {
-  return <section className="w-full bg-white shadow-lg rounded-lg px-2 py-6 lg:p-16">{children}</section>;
+  return <section className="w-full bg-white shadow-lg rounded-lg px-6 py-6 sm:p-16">{children}</section>;
 }

--- a/app/components/ui/forms.tsx
+++ b/app/components/ui/forms.tsx
@@ -1,5 +1,6 @@
+import type { ButtonHTMLAttributes, InputHTMLAttributes, ReactNode, TextareaHTMLAttributes } from 'react';
+
 import clsx from 'clsx';
-import type { InputHTMLAttributes, ReactNode } from 'react';
 
 type InputProps = InputHTMLAttributes<HTMLInputElement> & {
   label: ReactNode;
@@ -9,7 +10,7 @@ type InputProps = InputHTMLAttributes<HTMLInputElement> & {
 
 export function Input({ label, centerText = false, showLabel = true, ...props }: InputProps) {
   return (
-    <label className="flex w-full">
+    <label className="flex flex-col w-full">
       <span className={clsx({ 'bold pb-1': showLabel, 'sr-only': !showLabel })}>{label}</span>
       <input
         {...props}
@@ -18,5 +19,28 @@ export function Input({ label, centerText = false, showLabel = true, ...props }:
         })}
       />
     </label>
+  );
+}
+
+type TextAreaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  label: ReactNode;
+};
+
+export function TextArea({ label, ...props }: TextAreaProps) {
+  return (
+    <label className="flex flex-col w-full">
+      {label}
+      <textarea {...props} className="border border-gray-300 bg-grayBackground rounded-lg px-4 py-2 w-full" />
+    </label>
+  );
+}
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function Button({ ...props }: ButtonProps) {
+  return (
+    <button {...props} className="border-2 w-24 bg-red-700 text-white rounded-lg" type="submit">
+      Create
+    </button>
   );
 }

--- a/app/routes/groups_.new.tsx
+++ b/app/routes/groups_.new.tsx
@@ -1,4 +1,5 @@
 import { Card } from '~/components/ui/containers';
+import { Button, Input, TextArea } from '~/components/ui/forms';
 import { H1, H2 } from '~/components/ui/headers';
 
 export default function GroupNew() {
@@ -9,22 +10,16 @@ export default function GroupNew() {
           <H1>Create New Group</H1>
           <H2>Your Community Starts Here</H2>
           <Card>
-            <div className="flex pt-4">
-              <div className="flex-col">
+            <div className="flex pt-4 w-full">
+              <div className="w-1/2">
                 <div className="w-1/2 pb-4">
-                  <label>
-                    Group Name:
-                    <input className="bg-grayBackground" name="groupName" type="text" required />
-                  </label>
+                  <Input label="Group Name:" name="groupName" required />
                 </div>
                 <div className="w-1/2 pb-4">
-                  <label>
-                    Location:
-                    <input className="bg-grayBackground" name="location" type="text" required />
-                  </label>
+                  <Input label="Location:" name="location" required />
                 </div>
               </div>
-              <div className="flex-col">
+              <div className="w-full">
                 <div className="w-1/2 pb-4">
                   <label>
                     Group Topics:
@@ -37,28 +32,18 @@ export default function GroupNew() {
                   </label>
                 </div>
                 <div className="w-1/2 pb-4">
-                  <label>
-                    Discord Channel:
-                    <input className="bg-grayBackground" name="discordChannel" type="text" />
-                  </label>
+                  <Input label="Discord Channel:" name="discordChannel" />
                 </div>
               </div>
             </div>
             <div className="flex-col pb-4">
-              <label>
-                Description:
-                <textarea name="description" rows={5} cols={33} required></textarea>
-              </label>
+              <TextArea label="Description:" name="description" rows={5} required />
             </div>
             <div className="flex-row justify-end">
               <div>
                 <label>Attach Image</label>
               </div>
-              <div>
-                <button className="border-2 w-24 bg-red-700 text-white rounded-lg " type="submit">
-                  Create
-                </button>
-              </div>
+              <Button>Create</Button>
             </div>
           </Card>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@remix-run/dev": "^1.19.0",
         "@remix-run/eslint-config": "^1.19.0",
         "@remix-run/serve": "^1.19.0",
+        "@tailwindcss/forms": "^0.5.6",
         "@types/bcryptjs": "^2.4.2",
         "@types/react": "^18.0.35",
         "@types/react-dom": "^18.0.11",
@@ -3148,6 +3149,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.6.tgz",
+      "integrity": "sha512-Fw+2BJ0tmAwK/w01tEFL5TiaJBX1NLT1/YbWgvm7ws3Qcn11kiXxzNTEQDMs5V3mQemhB56l3u0i9dwdzSQldA==",
+      "dev": true,
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -9742,6 +9755,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -16301,6 +16323,15 @@
         "defer-to-connect": "^2.0.0"
       }
     },
+    "@tailwindcss/forms": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.6.tgz",
+      "integrity": "sha512-Fw+2BJ0tmAwK/w01tEFL5TiaJBX1NLT1/YbWgvm7ws3Qcn11kiXxzNTEQDMs5V3mQemhB56l3u0i9dwdzSQldA==",
+      "dev": true,
+      "requires": {
+        "mini-svg-data-uri": "^1.2.3"
+      }
+    },
     "@testing-library/dom": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.0.tgz",
@@ -21125,6 +21156,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
+    },
+    "mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
       "dev": true
     },
     "minimatch": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@remix-run/dev": "^1.19.0",
     "@remix-run/eslint-config": "^1.19.0",
     "@remix-run/serve": "^1.19.0",
+    "@tailwindcss/forms": "^0.5.6",
     "@types/bcryptjs": "^2.4.2",
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,5 +12,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/forms')],
 } satisfies Config;


### PR DESCRIPTION
## Summary

Create reusable form input components to use on our `/groups/new` route and beyond.

## Details

The input fields on our `/groups/new` route currently have a lot of repeated code. By making reusable components for these inputs, we can reduce code verbosity, keep our design more consistent, and make it easier to update our design if needed in the future.

Changes:

- Add a new `TextArea` component.
- Add a new `Button` component.
- Use our new reusable components in the `/groups/new` form.
- Update padding on the `Card` component. This is just a stylistic change to improve the UI.
- Add [`@tailwindcss/forms`](https://github.com/tailwindlabs/tailwindcss-forms) as a new dependency. This plugin provides a basic reset for form styles to give a better base for building out our form components.

## Screenshots/Recordings

### Before

![Screenshot 2023-09-11 at 20 30 24](https://github.com/social-plan-it/plan-it-social-web/assets/63323230/ab00939b-76de-46d4-adce-7e29d2dba656)

### After

![Screenshot 2023-09-11 at 20 30 44](https://github.com/social-plan-it/plan-it-social-web/assets/63323230/7df71bd2-b66f-471f-95d8-f15613a3fce1)

 <!--
Does it work on mobile? Make sure to include mobile screenshots or recordings!
-->

 <!--
Checklist before requesting a review:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code does not generate any new warnings or errors
- [x] New and existing unit tests pass locally with my changes (if relevant)
- [x] Screenshots and recordings for UI changes

-->
