### PR TITLE
[Groups] Implimented groups individual page and routing between them

### DIFF
--- a/app/components/layout/footer.tsx
+++ b/app/components/layout/footer.tsx
@@ -25,12 +25,12 @@ export default function Footer() {
           <ul className="mb-8">
             <li className="text-lg">Your Account</li>
             <li className="pb-1">
-              <a className="text-gray-400   font-thin" href="/">
+              <a className="text-gray-400   font-thin" href="/signup">
                 Sign Up
               </a>
             </li>
             <li className="pb-1">
-              <a className="text-gray-400  font-thin" href="/">
+              <a className="text-gray-400  font-thin" href="/login">
                 Log In
               </a>
             </li>
@@ -48,7 +48,7 @@ export default function Footer() {
           <ul className="mb-8">
             <li className="text-lg">Discover</li>
             <li className="pb-1">
-              <a className="text-gray-400  font-thin" href="/">
+              <a className="text-gray-400  font-thin" href="/groups">
                 Groups
               </a>
             </li>

--- a/app/components/ui/forms.tsx
+++ b/app/components/ui/forms.tsx
@@ -54,7 +54,7 @@ type LinkButtonProps = {
 export function LinkButton({ to, children, ...props }: LinkButtonProps) {
   return (
     <Link {...props} to={to} className="border-2 bg-red-700 text-white rounded-lg p-3 w-full text-center" type="submit">
-      Create {children}
+      {children}
     </Link>
   );
 }

--- a/app/components/ui/forms.tsx
+++ b/app/components/ui/forms.tsx
@@ -1,4 +1,5 @@
 import type { ButtonHTMLAttributes, InputHTMLAttributes, ReactNode, TextareaHTMLAttributes } from 'react';
+import { Link } from '@remix-run/react';
 
 import clsx from 'clsx';
 
@@ -37,10 +38,23 @@ export function TextArea({ label, ...props }: TextAreaProps) {
 
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement>;
 
-export function Button({ ...props }: ButtonProps) {
+export function Button({ children, ...props }: ButtonProps) {
   return (
-    <button {...props} className="border-2 w-24 bg-red-700 text-white rounded-lg" type="submit">
-      Create
+    <button {...props} className="border-2 bg-red-700 text-white rounded-lg" type="submit">
+      Create {children}
     </button>
+  );
+}
+
+type LinkButtonProps = {
+  children: ReactNode;
+  to: string;
+};
+
+export function LinkButton({ to, children, ...props }: LinkButtonProps) {
+  return (
+    <Link {...props} to={to} className="border-2 bg-red-700 text-white rounded-lg p-3 w-full text-center" type="submit">
+      Create {children}
+    </Link>
   );
 }

--- a/app/components/ui/forms.tsx
+++ b/app/components/ui/forms.tsx
@@ -41,7 +41,7 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement>;
 export function Button({ children, ...props }: ButtonProps) {
   return (
     <button {...props} className="border-2 bg-red-700 text-white rounded-lg" type="submit">
-      Create {children}
+      {children}
     </button>
   );
 }

--- a/app/routes/groups.tsx
+++ b/app/routes/groups.tsx
@@ -1,15 +1,26 @@
 import { Card } from '~/components/ui/containers';
 import { useGroups } from '~/hooks/useGroups';
+import { Link } from '@remix-run/react';
+import { LinkButton } from '~/components/ui/forms';
 
 export default function Group() {
   const groups = useGroups();
   return (
-    <Card>
-      <ul className="max-w-md space-y-1 text-gray-500 list-disc list-inside dark:text-gray-400">
-        {groups?.map((group) => {
-          return <li key={group.id}>{group.name}</li>;
-        })}
-      </ul>
-    </Card>
+    <>
+      <Card>
+        <ul className="max-w-md space-y-1 text-gray-500 list-disc list-inside dark:text-gray-400">
+          {groups?.map((group) => {
+            return (
+              <li key={group.id}>
+                <Link to={group.id}>{group.name}</Link>
+              </li>
+            );
+          })}
+        </ul>
+      </Card>
+      <div className="px-6 py-6 sm:px-16 max-w-sm">
+        <LinkButton to="/groups/new">New Group</LinkButton>
+      </div>
+    </>
   );
 }

--- a/app/routes/groups.tsx
+++ b/app/routes/groups.tsx
@@ -19,7 +19,7 @@ export default function Group() {
         </ul>
       </Card>
       <div className="px-6 py-6 sm:px-16 max-w-sm">
-        <LinkButton to="/groups/new">New Group</LinkButton>
+        <LinkButton to="/groups/new">Create New Group</LinkButton>
       </div>
     </>
   );

--- a/app/routes/groups_.$groupId.tsx
+++ b/app/routes/groups_.$groupId.tsx
@@ -1,0 +1,26 @@
+import type { LoaderFunction } from '@remix-run/node';
+import { useParams, useLoaderData, Link } from '@remix-run/react';
+import { db } from '~/modules/database/db.server';
+import { json } from '@remix-run/node';
+
+export const loader: LoaderFunction = async ({ params }) => {
+  const group = await db.group.findFirstOrThrow({ where: { id: params.groupId } });
+  return json({ group });
+};
+
+export default function GroupRoute() {
+  const data = useLoaderData<typeof loader>();
+
+  return (
+    <>
+      <Link to="/groups">back to groups</Link>
+      <h1>{data.group.name}</h1>
+      <p>{data.group.description}</p>
+    </>
+  );
+}
+
+export function ErrorBoundary() {
+  const { groupId } = useParams();
+  return <div className="error-container">There was an error loading group by the id {groupId}.</div>;
+}

--- a/app/routes/groups_.new.tsx
+++ b/app/routes/groups_.new.tsx
@@ -8,7 +8,6 @@ import { Card } from '~/components/ui/containers';
 import { Button, Input, TextArea } from '~/components/ui/forms';
 import { H1, H2 } from '~/components/ui/headers';
 
-
 export let action: ActionFunction = async ({ request }) => {
   const form = await request.formData();
   const name = form.get('groupName');

--- a/app/routes/groups_.new.tsx
+++ b/app/routes/groups_.new.tsx
@@ -1,6 +1,25 @@
+import type { ActionFunction } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+
+import { db } from '~/modules/database/db.server';
+
 import { Card } from '~/components/ui/containers';
 import { Button, Input, TextArea } from '~/components/ui/forms';
 import { H1, H2 } from '~/components/ui/headers';
+
+export let action: ActionFunction = async ({ request }) => {
+  const form = await request.formData();
+  const name = form.get('groupName');
+  const description = form.get('description');
+
+  if (typeof name !== 'string' || typeof description !== 'string') {
+    return { formError: `Form not submitted correctly.` };
+  }
+
+  await db.group.create({ data: { name, description } });
+
+  return redirect(`/groups/`);
+};
 
 export default function GroupNew() {
   return (
@@ -10,41 +29,43 @@ export default function GroupNew() {
           <H1>Create New Group</H1>
           <H2>Your Community Starts Here</H2>
           <Card>
-            <div className="flex pt-4 w-full">
-              <div className="w-1/2">
-                <div className="w-1/2 pb-4">
-                  <Input label="Group Name:" name="groupName" required />
+            <form method="post">
+              <div className="flex pt-4 w-full">
+                <div className="w-1/2">
+                  <div className="w-1/2 pb-4">
+                    <Input label="Group Name:" name="groupName" required />
+                  </div>
+                  <div className="w-1/2 pb-4">
+                    <Input label="Location:" name="location" required />
+                  </div>
                 </div>
-                <div className="w-1/2 pb-4">
-                  <Input label="Location:" name="location" required />
+                <div className="w-full">
+                  <div className="w-1/2 pb-4">
+                    <label>
+                      Group Topics:
+                      <select name="groupTopics" id="groupTopics">
+                        <option value="Tennis">Tennis</option>
+                        <option value="Golf">Golf</option>
+                        <option value="Pickleball">Pickleball</option>
+                        <option value="D&D">D&D</option>
+                      </select>
+                    </label>
+                  </div>
+                  <div className="w-1/2 pb-4">
+                    <Input label="Discord Channel:" name="discordChannel" />
+                  </div>
                 </div>
               </div>
-              <div className="w-full">
-                <div className="w-1/2 pb-4">
-                  <label>
-                    Group Topics:
-                    <select name="groupTopics" id="groupTopics">
-                      <option value="Tennis">Tennis</option>
-                      <option value="Golf">Golf</option>
-                      <option value="Pickleball">Pickleball</option>
-                      <option value="D&D">D&D</option>
-                    </select>
-                  </label>
-                </div>
-                <div className="w-1/2 pb-4">
-                  <Input label="Discord Channel:" name="discordChannel" />
-                </div>
+              <div className="flex-col pb-4">
+                <TextArea label="Description:" name="description" rows={5} required />
               </div>
-            </div>
-            <div className="flex-col pb-4">
-              <TextArea label="Description:" name="description" rows={5} required />
-            </div>
-            <div className="flex-row justify-end">
-              <div>
-                <label>Attach Image</label>
+              <div className="flex-row justify-end">
+                <div>
+                  <label>Attach Image</label>
+                </div>
+                <Button>Create</Button>
               </div>
-              <Button>Create</Button>
-            </div>
+            </form>
           </Card>
         </div>
       </div>

--- a/app/routes/groups_.new.tsx
+++ b/app/routes/groups_.new.tsx
@@ -64,7 +64,7 @@ export default function GroupNew() {
                 <div>
                   <label>Attach Image</label>
                 </div>
-                <Button>Create</Button>
+                <Button>Create New Group</Button>
               </div>
             </Form>
           </Card>

--- a/app/routes/groups_.new.tsx
+++ b/app/routes/groups_.new.tsx
@@ -1,11 +1,13 @@
 import type { ActionFunction } from '@remix-run/node';
 import { redirect } from '@remix-run/node';
+import { Form } from '@remix-run/react';
 
 import { db } from '~/modules/database/db.server';
 
 import { Card } from '~/components/ui/containers';
 import { Button, Input, TextArea } from '~/components/ui/forms';
 import { H1, H2 } from '~/components/ui/headers';
+
 
 export let action: ActionFunction = async ({ request }) => {
   const form = await request.formData();
@@ -29,7 +31,7 @@ export default function GroupNew() {
           <H1>Create New Group</H1>
           <H2>Your Community Starts Here</H2>
           <Card>
-            <form method="post">
+            <Form method="post">
               <div className="flex pt-4 w-full">
                 <div className="w-1/2">
                   <div className="w-1/2 pb-4">
@@ -65,7 +67,7 @@ export default function GroupNew() {
                 </div>
                 <Button>Create</Button>
               </div>
-            </form>
+            </Form>
           </Card>
         </div>
       </div>


### PR DESCRIPTION
 <!-- 
Please consider splitting up big PRs (more than 10-15 files) into several small ones for easier reviews
-->

Issue: #??

## Summary (1-2 sentences)

Created new individual group pages, Additionally added routing between 
- groups page <-> individual group page
- groups page <-> new groups page
- footer <-> login, signup, groups

## Details (reason and description of the changes)

new features, who doesn't; like it? :D

### Challenges (what problems did I face?) (optional)

- remix routing defaults to nested routing, which is a bit tricky until we figure out the syntax of it.
- the db needs a await to actually store things


### Solution (how did I fix the problems?) (optional)

elbow grease, Tony's knowledge and Google

### Sources (links that helped to resolve these challenges.) (optional)

https://remix.run/docs/en/main/file-conventions/routes#nested-urls-without-layout-nesting

## Screenshots/Recordings (if applicable)

main features:

https://github.com/social-plan-it/plan-it-social-web/assets/29219684/e6d21a15-25ef-42bf-a37c-81467241036a

error boundary:

https://github.com/social-plan-it/plan-it-social-web/assets/29219684/00b43f4f-629c-4f26-9b1c-b2a0256260bd




 <!--
Does it work on mobile? Make sure to include mobile screenshots or recordings!
-->


 <!--
Checklist before requesting a review:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My code does not generate any new warnings or errors
- [ ] New and existing unit tests pass locally with my changes (if relevant)
- [x] Screenshots and recordings for UI changes

-->

## Co-authored-by:
Tony Dang @tonydangblog
Elizabeth 
