### PR TITLE
update LoaderArgs, ActionArgs, and V2_MetaFunction, add small changes…

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -9,6 +9,7 @@ import type { EntryContext } from '@remix-run/node';
 import { RemixServer } from '@remix-run/react';
 import isbot from 'isbot';
 import { renderToPipeableStream } from 'react-dom/server';
+import { createReadableStreamFromReadable } from '@remix-run/node';
 
 const ABORT_DELAY = 5_000;
 
@@ -39,7 +40,7 @@ function handleBotRequest(
           responseHeaders.set('Content-Type', 'text/html');
 
           resolve(
-            new Response(body, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             }),
@@ -77,7 +78,7 @@ function handleBrowserRequest(
           responseHeaders.set('Content-Type', 'text/html');
 
           resolve(
-            new Response(body, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             }),

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, LoaderArgs } from '@remix-run/node';
+import type { LinksFunction, LoaderFunctionArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import stylesheet from './styles/tailwind.css';
 import { TopNav } from '~/components/layout/top-nav';
@@ -9,7 +9,7 @@ import { db } from './modules/database/db.server';
 
 export const links: LinksFunction = () => [{ rel: 'stylesheet', href: stylesheet }];
 
-export async function loader({ request }: LoaderArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const eventsPromise = db.event.findMany({ include: { group: true }, take: 24 });
   const groupsPromise = db.group.findMany({ take: 24 });
   const [events, groups] = await Promise.all([eventsPromise, groupsPromise]);

--- a/app/routes/_auth.login.tsx
+++ b/app/routes/_auth.login.tsx
@@ -1,4 +1,4 @@
-import type { LoaderArgs, ActionArgs } from '@remix-run/node';
+import type { LoaderFunctionArgs, ActionFunctionArgs } from '@remix-run/node';
 import { redirect } from '@remix-run/node';
 import { Form, Link, useActionData, useNavigation } from '@remix-run/react';
 import { Card } from '~/components/ui/containers';
@@ -10,7 +10,7 @@ import { SignInWithGoogleButton } from '~/modules/session/buttons';
 import { verifyGoogleToken } from '~/modules/session/google-auth.server';
 import { createUserSession, getUserSession } from '~/modules/session/session.server';
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const form = await request.formData();
   const email = form.get('email');
   const password = form.get('password');
@@ -66,7 +66,7 @@ export async function action({ request }: ActionArgs) {
   return redirect('/', { headers });
 }
 
-export async function loader({ request }: LoaderArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const session = await getUserSession(request);
   if (session) {
     return redirect('/');

--- a/app/routes/_auth.logout.tsx
+++ b/app/routes/_auth.logout.tsx
@@ -1,9 +1,9 @@
-import type { ActionArgs } from '@remix-run/node';
+import type { ActionFunctionArgs } from '@remix-run/node';
 import { redirect } from '@remix-run/node';
 
 import { logout } from '~/modules/session/session.server';
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   return logout(request);
 }
 

--- a/app/routes/_auth.signup.tsx
+++ b/app/routes/_auth.signup.tsx
@@ -1,4 +1,4 @@
-import type { LoaderArgs, ActionArgs } from '@remix-run/node';
+import type { LoaderFunctionArgs, ActionFunctionArgs } from '@remix-run/node';
 import { redirect } from '@remix-run/node';
 import { Form, Link, useActionData, useNavigation } from '@remix-run/react';
 import { z } from 'zod';
@@ -10,7 +10,7 @@ import { db } from '~/modules/database/db.server';
 import { badRequest } from '~/modules/response/response.server';
 import { createUserSession, getUserSession } from '~/modules/session/session.server';
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const signUpFormData = Object.fromEntries(await request.formData());
 
   const SignUpForm = z.object({
@@ -67,7 +67,7 @@ export async function action({ request }: ActionArgs) {
   return redirect('/', { headers });
 }
 
-export async function loader({ request }: LoaderArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const session = await getUserSession(request);
   if (session) {
     return redirect('/');

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,11 +1,11 @@
 import { useLoaderData } from '@remix-run/react';
-import { type V2_MetaFunction } from '@remix-run/react';
+import { type MetaFunction } from '@remix-run/react';
 import { db } from '~/modules/database/db.server';
 import HeroSection from '~/components/marketing/hero-section';
 import { EventsSection } from '../components/marketing/events-section';
 import { BenefitsSection } from '~/components/marketing/benefits-section';
 
-export const meta: V2_MetaFunction = () => {
+export const meta: MetaFunction = () => {
   return [{ title: 'Plan It Social' }];
 };
 


### PR DESCRIPTION
Issue: #71 

## Summary 
After running 'npm run typecheck', there were several errors. Fixed some of them by replacing deprecated imports with new ones. Also, added a small import in the entry.server.tsx file. 

## Details 
- LoaderArgs -> LoaderFunctionArgs
- ActionArgs -> ActionFunctionArgs
- V2_MetaFunction -> MetaFunction
- Add createReadableStreamFromReadable in entry.server.tsx


### Challenges 
All three places with errors seemed similar and related to JsonifyObject. (see screenshots below):
 - app/routes/_auth.login.tsx 
 - app/routes/search.tsx 
 - app/routes/groups_.$groupId.tsx 

### Solution
Probably, this is Remix's bug and the solution could be [this](https://github.com/remix-run/remix/issues/7246). But it seemed a bit advanced to me. 

### Sources 
The general guide by Brooks Lybrand is [here](https://x.com/BrooksLybrand/status/1704265835546578989).
[Here](https://remix.run/docs/en/main/start/v2#removal-of-exported-polyfills) is a solution related to entry.server.tsx. 


## Screenshots of the rest errors (all the same)
<img width="975" alt="Screenshot 2023-10-12 at 5 43 20 PM" src="https://github.com/social-plan-it/plan-it-social-web/assets/114109736/c14e62e5-d567-4bab-b49c-cffa785009f5">
<img width="976" alt="Screenshot 2023-10-12 at 5 43 39 PM" src="https://github.com/social-plan-it/plan-it-social-web/assets/114109736/76c1a4bf-3617-433d-8059-8705142811cf">
<img width="1044" alt="Screenshot 2023-10-12 at 6 07 27 PM" src="https://github.com/social-plan-it/plan-it-social-web/assets/114109736/764b5399-7b63-47ee-8e07-ad94c397cce6">
