### PR TITLE
Test Typecheck in GitHub action and Upgrade to Remix 2.1.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,3 +9,5 @@ jobs:
         run: npm i
       - name: Run ESLint
         run: npm run lint
+      - name: Run Typecheck
+        run: npm run typescheck

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Run ESLint
         run: npm run lint
       - name: Run Typecheck
-        run: npm run typescheck
+        run: npm run typecheck

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ If you're used to using the `vercel dev` command provided by [Vercel CLI](https:
 
 Please utilize our formatting and linting command `npm run lint`. Also included in our documentation, are great instructions on how to [setup this functionality to automatically run on save in VS code](./docs/formatting-and-linting.md).
 
+## Type Checking
+
+This project uses TypeScript to enforce static typing, enhancing code quality and catching potential issues early in the development process. Before submitting a pull request, ensure that your changes pass TypeScript type checking. Run the following command locally:
+
+```bash
+npm run typecheck
+```
+
 ### VS Code Setup
 
 Use the following settings to format your files on save:

--- a/app/routes/_auth.login.tsx
+++ b/app/routes/_auth.login.tsx
@@ -75,7 +75,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export default function Component() {
-  const actionData = useActionData();
+  const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const isPending = navigation.state === 'submitting' || navigation.state === 'loading';
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
       "dependencies": {
         "@headlessui/react": "^1.7.15",
         "@prisma/client": "^5.1.1",
-        "@remix-run/node": "^2.0.0",
-        "@remix-run/react": "^2.0.0",
+        "@remix-run/node": "2.1.0",
+        "@remix-run/react": "2.1.0",
         "bcryptjs": "^2.4.3",
         "clsx": "^2.0.0",
         "google-auth-library": "^9.0.0",
@@ -18,9 +18,9 @@
         "zod": "^3.22.2"
       },
       "devDependencies": {
-        "@remix-run/dev": "^2.0.0",
-        "@remix-run/eslint-config": "^2.0.0",
-        "@remix-run/serve": "^2.0.0",
+        "@remix-run/dev": "2.1.0",
+        "@remix-run/eslint-config": "2.1.0",
+        "@remix-run/serve": "2.1.0",
         "@tailwindcss/forms": "^0.5.6",
         "@types/bcryptjs": "^2.4.2",
         "@types/react": "^18.0.35",
@@ -1704,7 +1704,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.3.1.tgz",
       "integrity": "sha512-6QkILNyfeeN67BNEPEtkgh3Xo2tm6D7V+UhrkBbRHqKw9CTaz/vvTP/ROwYSP/3JT2MtIutZm/EnhxUiuOPVDA==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
@@ -1713,9 +1713,9 @@
       "integrity": "sha512-y5qbUi3ql2Xg7XraqcXEdMHh0MocBfnBzDn5GbV1xk23S3Mq8MGs+VjacTNiBh3dtEdUERCrUUG7Z3QaJ+h79w=="
     },
     "node_modules/@remix-run/dev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.0.0.tgz",
-      "integrity": "sha512-cdUOuywlC6uHZPGhK+ASGBBKXUUtz94OFsAmRziu7lH7I3GZJ7llExlM+FtkQYEdD0u00/1FSnv2xjXAq/sHzw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.1.0.tgz",
+      "integrity": "sha512-Hn5lw46F+a48dp5uHKe68ckaHgdStW4+PmLod+LMFEqrMbkF0j4XD1ousebxlv989o0Uy/OLgfRMgMy4cBOvHg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.21.8",
@@ -1727,7 +1727,7 @@
         "@babel/traverse": "^7.21.5",
         "@mdx-js/mdx": "^2.3.0",
         "@npmcli/package-json": "^4.0.1",
-        "@remix-run/server-runtime": "2.0.0",
+        "@remix-run/server-runtime": "2.1.0",
         "@types/mdx": "^2.0.5",
         "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
@@ -1774,7 +1774,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@remix-run/serve": "^2.0.0",
+        "@remix-run/serve": "^2.1.0",
         "typescript": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -1802,9 +1802,9 @@
       }
     },
     "node_modules/@remix-run/eslint-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-2.0.0.tgz",
-      "integrity": "sha512-zGkP8BGKDU41TkWnWMqkz/OsNacYoqiTAGzc8PzkmILdEHFfj6IFiseCLMdzZppYFLoZQGo8/Lpe1b7IidxDOg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-2.1.0.tgz",
+      "integrity": "sha512-yfeUnHpUG+XveujMi6QODKMGhs5CvKWCKzASU397BPXiPWbMv6r2acfODSWK64ZdBMu9hcLbOb42GBFydVQeHA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.21.8",
@@ -1839,12 +1839,12 @@
       }
     },
     "node_modules/@remix-run/express": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.0.0.tgz",
-      "integrity": "sha512-wNu+ajtSzcjju+zsAA3uaKCuwwpYKLnE8RI5mgA0Cr/KMnkJxKO6QZN4q1GkB65GyWezemhi/xCFJecy1Q8UXg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.1.0.tgz",
+      "integrity": "sha512-R5myPowQx6LYWY3+EqP42q19MOCT3+ZGwb2f0UKNs9a34R8U3nFpGWL7saXryC+To+EasujEScc8rTQw5Pftog==",
       "dev": true,
       "dependencies": {
-        "@remix-run/node": "2.0.0"
+        "@remix-run/node": "2.1.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1860,12 +1860,12 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.0.0.tgz",
-      "integrity": "sha512-wICp1W3Aue6CojlfSQZoKCQYnJ+7U/kk0poqQr6+CNihY5QPStzOce3hNYwB9NweagbZsMf80x47m6ef6a9psQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.1.0.tgz",
+      "integrity": "sha512-TeSgjXnZUUlmw5FVpBVnXY7MLpracjdnwFNwoJE5NQkiUEFnGD/Yhvk4F2fOCkszqc2Z25KRclc5noweyiFu6Q==",
       "dependencies": {
-        "@remix-run/server-runtime": "2.0.0",
-        "@remix-run/web-fetch": "^4.4.0",
+        "@remix-run/server-runtime": "2.1.0",
+        "@remix-run/web-fetch": "^4.4.1",
         "@remix-run/web-file": "^3.1.0",
         "@remix-run/web-stream": "^1.1.0",
         "@web3-storage/multipart-parser": "^1.0.0",
@@ -1886,13 +1886,13 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.0.0.tgz",
-      "integrity": "sha512-h/xXrwupxXoWGvEC1JnDeh9D7lfLTQNiKaEXvWKZwlfNuKeI8nIKXpy+JDDHhloUybe4tpMKztyCqdNCYqfKWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.1.0.tgz",
+      "integrity": "sha512-DeYgfsvNxHqNn29sGA3XsZCciMKo2EFTQ9hHkuVPTsJXC4ipHr6Dja1j6UzZYPe/ZuKppiuTjueWCQlE2jOe1w==",
       "dependencies": {
-        "@remix-run/router": "1.9.0",
-        "@remix-run/server-runtime": "2.0.0",
-        "react-router-dom": "6.16.0"
+        "@remix-run/router": "1.10.0",
+        "@remix-run/server-runtime": "2.1.0",
+        "react-router-dom": "6.17.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1909,21 +1909,21 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.9.0.tgz",
-      "integrity": "sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.10.0.tgz",
+      "integrity": "sha512-Lm+fYpMfZoEucJ7cMxgt4dYt8jLfbpwRCzAjm9UgSLOkmlqo9gupxt6YX3DY0Fk155NT9l17d/ydi+964uS9Lw==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/serve": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.0.0.tgz",
-      "integrity": "sha512-/KGWq6wyXw0ad6osngS+7mW+C7jNKbKnkEaQ7NRBT8AO5pD5S/OUoVeOWQm/4QJYbBQ+wawF2QN4qmbK5l1MfA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.1.0.tgz",
+      "integrity": "sha512-XHI+vPYz217qrg1QcV38TTPlEBTzMJzAt0SImPutyF0S2IBrZGZIFMEsspI0i0wNvdcdQz1IqmSx+mTghzW8eQ==",
       "dev": true,
       "dependencies": {
-        "@remix-run/express": "2.0.0",
-        "@remix-run/node": "2.0.0",
+        "@remix-run/express": "2.1.0",
+        "@remix-run/node": "2.1.0",
         "chokidar": "^3.5.3",
         "compression": "^1.7.4",
         "express": "^4.17.1",
@@ -1939,17 +1939,16 @@
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.0.0.tgz",
-      "integrity": "sha512-HaNszj/mp/A1Qz5sVupVIXqDyeEni3nwW5iKDqGAqv0n8E6FRkzEhOtAJypRABcKWBq0M9VM3fm6IO0vaMti8Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.1.0.tgz",
+      "integrity": "sha512-Uz69yF4Gu6F3VYQub3JgDo9godN8eDMeZclkadBTAWN7bYLonu0ChR/GlFxS35OLeF7BDgudxOSZob0nE1WHNg==",
       "dependencies": {
-        "@remix-run/router": "1.9.0",
+        "@remix-run/router": "1.10.0",
         "@types/cookie": "^0.4.1",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.4.1",
         "set-cookie-parser": "^2.4.8",
-        "source-map": "^0.7.3",
-        "type-fest": "^4.0.0"
+        "source-map": "^0.7.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -9586,7 +9585,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.3.1.tgz",
       "integrity": "sha512-Wp2msQIlMPHe+5k5Od6xnsI/WNG7UJGgFUJgqv/ygc7kOECZapcSz/iU4NIEzISs3H1W9sFLjAPbg/gOqqtB7A==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/engines": "5.3.1"
@@ -9809,11 +9808,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.16.0.tgz",
-      "integrity": "sha512-VT4Mmc4jj5YyjpOi5jOf0I+TYzGpvzERy4ckNSvSh2RArv8LLoCxlsZ2D+tc7zgjxcY34oTz2hZaeX5RVprKqA==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.17.0.tgz",
+      "integrity": "sha512-YJR3OTJzi3zhqeJYADHANCGPUu9J+6fT5GLv82UWRGSxu6oJYCKVmxUcaBQuGm9udpWmPsvpme/CdHumqgsoaA==",
       "dependencies": {
-        "@remix-run/router": "1.9.0"
+        "@remix-run/router": "1.10.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9823,12 +9822,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.16.0.tgz",
-      "integrity": "sha512-aTfBLv3mk/gaKLxgRDUPbPw+s4Y/O+ma3rEN1u8EgEpLpPe6gNjIsWt9rxushMHHMb7mSwxRGdGlGdvmFsyPIg==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.17.0.tgz",
+      "integrity": "sha512-qWHkkbXQX+6li0COUUPKAUkxjNNqPJuiBd27dVwQGDNsuFBdMbrS6UZ0CLYc4CsbdLYTckn4oB4tGDuPZpPhaQ==",
       "dependencies": {
-        "@remix-run/router": "1.9.0",
-        "react-router": "6.16.0"
+        "@remix-run/router": "1.10.0",
+        "react-router": "6.17.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -11362,17 +11361,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-fest": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.3.1.tgz",
-      "integrity": "sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -11455,7 +11443,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "@headlessui/react": "^1.7.15",
     "@prisma/client": "^5.1.1",
-    "@remix-run/node": "^2.0.0",
-    "@remix-run/react": "^2.0.0",
+    "@remix-run/node": "2.1.0",
+    "@remix-run/react": "2.1.0",
     "bcryptjs": "^2.4.3",
     "clsx": "^2.0.0",
     "google-auth-library": "^9.0.0",
@@ -28,9 +28,9 @@
     "zod": "^3.22.2"
   },
   "devDependencies": {
-    "@remix-run/dev": "^2.0.0",
-    "@remix-run/eslint-config": "^2.0.0",
-    "@remix-run/serve": "^2.0.0",
+    "@remix-run/dev": "2.1.0",
+    "@remix-run/eslint-config": "2.1.0",
+    "@remix-run/serve": "2.1.0",
     "@tailwindcss/forms": "^0.5.6",
     "@types/bcryptjs": "^2.4.2",
     "@types/react": "^18.0.35",


### PR DESCRIPTION
 <!-- 
Please consider splitting up big PRs (more than 10-15 files) into several small ones for easier reviews
-->

Issue: 

## Summary (1-2 sentences)
- Test check.yml file for checking types within GitHub Actions. 
- Upgrading Remix 2.0.0 -> 2.1.0. It allowed to get rid of "Jsonify Type" errors. 

## Commands
```
npx upgrade-remix
```
## Sources
About the Remix 2.1.0 minor upgrade: https://github.com/remix-run/remix/releases

## Co-authors: 
@tonydangblog, Tony Dang
@eiffelwong1, Sing Wong