### PR TITLE
Splat route for the 404 page

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -84,22 +84,6 @@ export function ErrorBoundary() {
   const error = useRouteError();
 
   if (isRouteErrorResponse(error)) {
-    if (error.status === 404) {
-      return (
-        <Shell>
-          <ErrorMessage>
-            <div className="flex">
-              <img
-                className="h-0 w-0 collapse sm:visible sm:h-60 sm:w-60"
-                src="/imgs/404-not-found.png"
-                alt="Resource not found"
-              />
-              <h1>The resource you are looking for does not exist.</h1>
-            </div>
-          </ErrorMessage>
-        </Shell>
-      );
-    }
     return (
       <Shell>
         <ErrorMessage>

--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -1,0 +1,26 @@
+import { Link, useLocation } from '@remix-run/react';
+import { ErrorMessage } from '~/components/ui/error-message';
+
+export async function loader() {
+  throw new Response('Not found', { status: 404 });
+}
+
+export function ErrorBoundary() {
+  const location = useLocation();
+
+  return (
+    <ErrorMessage>
+      <div className="flex flex-col gap-4">
+        <img
+          className="h-0 w-0 collapse sm:visible sm:h-60 sm:w-60"
+          src="/imgs/404-not-found.png"
+          alt="Page not found"
+        />
+        <h1>
+          The page <span className="text-xl">{location.pathname}</span> you are looking for does not exist.
+        </h1>
+        <Link to="/">Visit our Home page here </Link>
+      </div>
+    </ErrorMessage>
+  );
+}

--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -10,16 +10,19 @@ export function ErrorBoundary() {
 
   return (
     <ErrorMessage>
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col items-center py-4">
         <img
           className="h-0 w-0 collapse sm:visible sm:h-60 sm:w-60"
           src="/imgs/404-not-found.png"
           alt="Page not found"
         />
-        <h1>
-          The page <span className="text-xl">{location.pathname}</span> you are looking for does not exist.
-        </h1>
-        <Link to="/">Visit our Home page here </Link>
+        <h1 className="mt-4 text-2xl sm:text-6xl tracking-tight">Page not found</h1>
+        <p className="mt-6 text-base text-gray-600">
+          The page <span className="font-bold">{location.pathname}</span> you are looking for does not exist.
+        </p>
+        <Link to="/" className="mt-12 rounded-md bg-[#028090] hover:bg-[#018C9E] text-white px-3.5 py-2.5 ">
+          Go back home
+        </Link>
       </div>
     </ErrorMessage>
   );


### PR DESCRIPTION
Issue: #69>

## Summary (1-2 sentences)
Created a splat route for handling all "page not found" errors. 

## Details (reason and description of the changes)
[Remix docs](https://remix.run/docs/en/main/guides/not-found) recommends using splat routes for this case. Moved the 404 handling logic from ErrorBoundary in root.tsx to a separate file ($.tsx) in the routes folder.

### Solution 
Thanks to Kent C. Dodds for the [implementation](https://github.com/kentcdodds/kentcdodds.com/blob/main/app/routes/%24.tsx).

### Challenges 
Even with the comments, it's not fully clear why Kent uses this code:
```javascript
export default function NotFound() {
  // due to the loader, this component will never be rendered, but we'll return
  // the error boundary just in case.
  return <ErrorBoundary />
}
```

## Design has changed a bit 🙂 
https://github.com/social-plan-it/plan-it-social-web/assets/114109736/a10a9596-f37c-43ee-bbb6-34ec79c6e061

Co-authored-by: @eiffelwong1 Sing Wong
