### PR TITLE
Creating a .env file is not needed node to read env

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,18 +17,12 @@ jobs:
         run: npm ci
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
-      - name: Create .env with Github Secrets and run script
-        run: |
-          touch .env
-          echo DATABASE_URL=$DATABASE_URL >> .env
-          echo PUBLIC_GOOGLE_CLIENT_ID=$PUBLIC_GOOGLE_CLIENT_ID >> .env
-          echo SESSION_SECRET=$SESSION_SECRET >> .env
+      - name: Run Playwright tests
+        run: npx playwright test
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.PUBLIC_GOOGLE_CLIENT_ID }}
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
-      - name: Run Playwright tests
-        run: npx playwright test
       - uses: actions/upload-artifact@v3
         if: always()
         with:


### PR DESCRIPTION
## Summary (1-2 sentences)

moved env under `npx playwright test` in github workflows
removed github step of creating .env file

## Details (reason and description of the changes)

I believe that as long as the variable is in env, node doesn't need to have a .env file to access variables with `process.env` (similar to python)

