### PR TITLE
Fix login bug in matchesHash

### DIFF
--- a/app/routes/_auth.login.tsx
+++ b/app/routes/_auth.login.tsx
@@ -57,7 +57,9 @@ export async function action({ request }: ActionFunctionArgs) {
     return { status: 400, message: "Credentials don't match. Please try again." };
   }
 
-  if (!matchesHash(password.toString(), passwordObject.hash)) {
+  const passwordCorrect = await matchesHash(password.toString(), passwordObject.hash);
+
+  if (!passwordCorrect) {
     return { status: 400, message: "Credentials don't match. Please try again." };
   }
 


### PR DESCRIPTION
## Summary 
There was a bug: user can be logged in even with an incorrect password. 

## Details 
We fixed the bug by adding an 'async' to the matchesHash function. 
