### PR TITLE
Reusable Button Component with Style Variants

### DIFF
--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -13,46 +13,28 @@ export function Button({ variant, buttonStyle, size, children, ...props }: Butto
   let styleClasses = '';
   let sizeClasses = '';
 
-  switch (variant) {
-    case 'primary':
-      variantClasses = 'bg-primary text-white focus:ring-gray-300 hover:bg-gray-900';
-      break;
-    case 'secondary':
-      variantClasses = 'bg-secondary focus:ring-teal-300 hover:bg-teal-200';
-      break;
-    case 'warm':
-      variantClasses = 'bg-warm text-white focus:ring-red-300 hover:bg-red-700';
-      break;
-    case 'outlined':
-      variantClasses = 'bg-white text-primary border border-gray-200 focus:ring-gray-300 hover:bg-gray-100';
-      break;
-    default:
-      variantClasses = 'bg-primary text-white focus:ring-gray-300 hover:bg-gray-900';
+  if (variant === 'primary') {
+    variantClasses = 'bg-primary text-white focus:ring-gray-300 hover:bg-gray-900';
+  } else if (variant === 'secondary') {
+    variantClasses = 'bg-secondary focus:ring-teal-300 hover:bg-teal-200';
+  } else if (variant === 'warm') {
+    variantClasses = 'bg-warm text-white focus:ring-red-300 hover:bg-red-700';
+  } else {
+    variantClasses = 'bg-white text-primary border border-gray-200 focus:ring-gray-300 hover:bg-gray-100';
   }
 
-  switch (buttonStyle) {
-    case 'rounded':
-      styleClasses = 'rounded-lg';
-      break;
-    case 'fullyRounded':
-      styleClasses = 'rounded-full';
-      break;
-    default:
-      styleClasses = 'rounded-lg';
+  if (buttonStyle === 'rounded') {
+    styleClasses = 'rounded-lg';
+  } else {
+    styleClasses = 'rounded-full';
   }
 
-  switch (size) {
-    case 'small':
-      sizeClasses = 'px-3 py-2 text-sm';
-      break;
-    case 'medium':
-      sizeClasses = 'px-5 py-2.5 text-sm';
-      break;
-    case 'large':
-      sizeClasses = 'px-5 py-3 text-base';
-      break;
-    default:
-      sizeClasses = 'px-5 py-2.5 text-sm';
+  if (size === 'small') {
+    sizeClasses = 'px-3 py-2 text-sm';
+  } else if (size === 'medium') {
+    sizeClasses = 'px-5 py-2.5 text-sm';
+  } else if (size === 'large') {
+    sizeClasses = 'px-5 py-3 text-base';
   }
 
   return (

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -7,35 +7,40 @@ type ButtonProps = {
   children: React.ReactNode;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
-export function Button({ variant, buttonStyle, size }: ButtonProps) {
-  let baseClasses = 'w-full sm:w-fit me-2 mb-2 text-center font-medium focus:outline-none focus:ring-4';
+export function Button({ variant, buttonStyle, size, children, ...props }: ButtonProps) {
+  const baseClasses = 'w-full sm:w-fit me-2 mb-2 text-center font-medium focus:outline-none focus:ring-4';
   let variantClasses = '';
-  let styleClasses = '';
+  const styleClasses = buttonStyle === 'rounded' ? 'rounded-lg' : 'rounded-full';
   let sizeClasses = '';
 
-  if (variant === 'primary') {
-    variantClasses = 'bg-primary text-white focus:ring-gray-300 hover:bg-gray-900';
-  } else if (variant === 'secondary') {
-    variantClasses = 'bg-secondary focus:ring-teal-300 hover:bg-teal-200';
-  } else if (variant === 'warm') {
-    variantClasses = 'bg-warm text-white focus:ring-red-300 hover:bg-red-700';
-  } else {
-    variantClasses = 'bg-white text-primary border border-gray-200 focus:ring-gray-300 hover:bg-gray-100';
+  switch (variant) {
+    case 'primary':
+      variantClasses = 'bg-primary text-white focus:ring-gray-300 hover:bg-gray-900';
+      break;
+    case 'secondary':
+      variantClasses = 'bg-secondary focus:ring-teal-300 hover:bg-teal-200';
+      break;
+    case 'warm':
+      variantClasses = 'bg-warm text-white focus:ring-red-300 hover:bg-red-700';
+      break;
+    default:
+      variantClasses = 'bg-white text-primary border border-gray-200 focus:ring-gray-300 hover:bg-gray-100';
   }
 
-  if (buttonStyle === 'rounded') {
-    styleClasses = 'rounded-lg';
-  } else {
-    styleClasses = 'rounded-full';
+  switch (size) {
+    case 'small':
+      sizeClasses = 'px-3 py-2 text-sm';
+      break;
+    case 'medium':
+      sizeClasses = 'px-5 py-2.5 text-sm';
+      break;
+    default:
+      sizeClasses = 'px-5 py-3 text-base';
   }
 
-  if (size === 'small') {
-    sizeClasses = 'px-3 py-2 text-sm';
-  } else if (size === 'medium') {
-    sizeClasses = 'px-5 py-2.5 text-sm';
-  } else {
-    sizeClasses = 'px-5 py-3 text-base';
-  }
-
-  return <button className={`${baseClasses} ${variantClasses} ${styleClasses} ${sizeClasses}`}>Hello world</button>;
+  return (
+    <button className={`${baseClasses} ${variantClasses} ${styleClasses} ${sizeClasses}`} {...props}>
+      {children}
+    </button>
+  );
 }

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -1,0 +1,41 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+type ButtonProps = {
+  variant: 'primary' | 'secondary' | 'warm' | 'outlined';
+  buttonStyle: 'rounded' | 'fullyRounded';
+  size: 'small' | 'medium' | 'large';
+  children: React.ReactNode;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function Button({ variant, buttonStyle, size }: ButtonProps) {
+  let baseClasses = 'w-full sm:w-fit me-2 mb-2 text-center font-medium focus:outline-none focus:ring-4';
+  let variantClasses = '';
+  let styleClasses = '';
+  let sizeClasses = '';
+
+  if (variant === 'primary') {
+    variantClasses = 'bg-primary text-white focus:ring-gray-300 hover:bg-gray-900';
+  } else if (variant === 'secondary') {
+    variantClasses = 'bg-secondary focus:ring-teal-300 hover:bg-teal-200';
+  } else if (variant === 'warm') {
+    variantClasses = 'bg-warm text-white focus:ring-red-300 hover:bg-red-700';
+  } else {
+    variantClasses = 'bg-white text-primary border border-gray-200 focus:ring-gray-300 hover:bg-gray-100';
+  }
+
+  if (buttonStyle === 'rounded') {
+    styleClasses = 'rounded-lg';
+  } else {
+    styleClasses = 'rounded-full';
+  }
+
+  if (size === 'small') {
+    sizeClasses = 'px-3 py-2 text-sm';
+  } else if (size === 'medium') {
+    sizeClasses = 'px-5 py-2.5 text-sm';
+  } else {
+    sizeClasses = 'px-5 py-3 text-base';
+  }
+
+  return <button className={`${baseClasses} ${variantClasses} ${styleClasses} ${sizeClasses}`}>Hello world</button>;
+}

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -1,16 +1,16 @@
 import type { ButtonHTMLAttributes } from 'react';
 
-type ButtonProps = {
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   variant: 'primary' | 'secondary' | 'warm' | 'outlined';
   buttonStyle: 'rounded' | 'fullyRounded';
   size: 'small' | 'medium' | 'large';
   children: React.ReactNode;
-} & ButtonHTMLAttributes<HTMLButtonElement>;
+};
 
 export function Button({ variant, buttonStyle, size, children, ...props }: ButtonProps) {
   const baseClasses = 'w-full sm:w-fit me-2 mb-2 text-center font-medium focus:outline-none focus:ring-4';
   let variantClasses = '';
-  const styleClasses = buttonStyle === 'rounded' ? 'rounded-lg' : 'rounded-full';
+  let styleClasses = '';
   let sizeClasses = '';
 
   switch (variant) {
@@ -23,8 +23,22 @@ export function Button({ variant, buttonStyle, size, children, ...props }: Butto
     case 'warm':
       variantClasses = 'bg-warm text-white focus:ring-red-300 hover:bg-red-700';
       break;
-    default:
+    case 'outlined':
       variantClasses = 'bg-white text-primary border border-gray-200 focus:ring-gray-300 hover:bg-gray-100';
+      break;
+    default:
+      variantClasses = 'bg-primary text-white focus:ring-gray-300 hover:bg-gray-900';
+  }
+
+  switch (buttonStyle) {
+    case 'rounded':
+      styleClasses = 'rounded-lg';
+      break;
+    case 'fullyRounded':
+      styleClasses = 'rounded-full';
+      break;
+    default:
+      styleClasses = 'rounded-lg';
   }
 
   switch (size) {
@@ -34,8 +48,11 @@ export function Button({ variant, buttonStyle, size, children, ...props }: Butto
     case 'medium':
       sizeClasses = 'px-5 py-2.5 text-sm';
       break;
-    default:
+    case 'large':
       sizeClasses = 'px-5 py-3 text-base';
+      break;
+    default:
+      sizeClasses = 'px-5 py-2.5 text-sm';
   }
 
   return (

--- a/app/routes/about-us.tsx
+++ b/app/routes/about-us.tsx
@@ -1,7 +1,21 @@
+import { Button } from '~/components/ui/button';
+
 export default function AboutUs() {
   return (
     <>
       <h1 className="text-2xl my-5">The About Page For Social Plan-it</h1>
+      <Button variant="primary" buttonStyle="rounded" size="large">
+        First
+      </Button>
+      <Button variant="secondary" buttonStyle="fullyRounded" size="medium">
+        Second
+      </Button>
+      <Button variant="outlined" buttonStyle="rounded" size="small">
+        Third
+      </Button>
+      <Button variant="warm" buttonStyle="fullyRounded" size="large">
+        Third
+      </Button>
     </>
   );
 }

--- a/app/routes/about-us.tsx
+++ b/app/routes/about-us.tsx
@@ -14,7 +14,7 @@ export default function AboutUs() {
         Third
       </Button>
       <Button variant="warm" buttonStyle="fullyRounded" size="large">
-        Third
+        Fourth
       </Button>
     </>
   );

--- a/app/routes/about-us.tsx
+++ b/app/routes/about-us.tsx
@@ -4,17 +4,17 @@ export default function AboutUs() {
   return (
     <>
       <h1 className="text-2xl my-5">The About Page For Social Plan-it</h1>
-      <Button variant="primary" buttonStyle="rounded" size="large">
-        First
+      <Button variant="primary" buttonStyle="rounded" size="medium">
+        Primary Rounded Medium
       </Button>
-      <Button variant="secondary" buttonStyle="fullyRounded" size="medium">
-        Second
+      <Button variant="secondary" buttonStyle="fullyRounded" size="small">
+        Secondary Fully Rounded Small
       </Button>
-      <Button variant="outlined" buttonStyle="rounded" size="small">
-        Third
+      <Button variant="warm" buttonStyle="rounded" size="large">
+        Warm Rounded Large
       </Button>
-      <Button variant="warm" buttonStyle="fullyRounded" size="large">
-        Fourth
+      <Button variant="outlined" buttonStyle="fullyRounded" size="medium">
+        Outlined Fully Rounded Medium
       </Button>
     </>
   );

--- a/app/routes/about-us.tsx
+++ b/app/routes/about-us.tsx
@@ -1,21 +1,3 @@
-import { Button } from '~/components/ui/button';
-
 export default function AboutUs() {
-  return (
-    <>
-      <h1 className="text-2xl my-5">The About Page For Social Plan-it</h1>
-      <Button variant="primary" buttonStyle="rounded" size="medium">
-        Primary Rounded Medium
-      </Button>
-      <Button variant="secondary" buttonStyle="fullyRounded" size="small">
-        Secondary Fully Rounded Small
-      </Button>
-      <Button variant="warm" buttonStyle="rounded" size="large">
-        Warm Rounded Large
-      </Button>
-      <Button variant="outlined" buttonStyle="fullyRounded" size="medium">
-        Outlined Fully Rounded Medium
-      </Button>
-    </>
-  );
+  return <h1 className="text-2xl my-5">The About Page For Social Plan-it</h1>;
 }

--- a/app/routes/groups_.new.tsx
+++ b/app/routes/groups_.new.tsx
@@ -5,7 +5,9 @@ import { Form } from '@remix-run/react';
 import { db } from '~/modules/database/db.server';
 
 import { Card } from '~/components/ui/containers';
-import { Button, Input, TextArea } from '~/components/ui/forms';
+import { Input, TextArea } from '~/components/ui/forms';
+import { Button } from '~/components/ui/button';
+
 import { H1, H2 } from '~/components/ui/headers';
 
 export let action: ActionFunction = async ({ request }) => {
@@ -64,7 +66,9 @@ export default function GroupNew() {
                 <div>
                   <label>Attach Image</label>
                 </div>
-                <Button>Create New Group</Button>
+                <Button variant="warm" buttonStyle="fullyRounded" size="large">
+                  Create a group
+                </Button>
               </div>
             </Form>
           </Card>


### PR DESCRIPTION
 <!-- 
Please consider splitting up big PRs (more than 10-15 files) into several small ones for easier reviews
-->

Issue: #88 

## Summary
This PR introduces a new button component with 24 styles for consistency and easier UI development. 

## Details 
Button accepts non-optional props:
 - variant: primary, secondary, warm, outlined
 - buttonStyle: rounded or fullyRounded
 - size: small, medium, and large

### Challenges
There is already an exported Button function in forms.tsx. It's not used there because the new component can make code a bit cumbersome. 

### Solution 
@tonydangblog recommended placing the component into src/components/button.tsx. 

### Alternative implementations
This component could be more customizable. For example, accept classNames and merge them with the [tailwind-merge](https://www.npmjs.com/package/tailwind-merge) package. Also, there are many other props such as icons, labels, disabled, etc...We can consider including some of them in the future. 

### Sources 
Some tailwind classes are used from [Flowbite](https://flowbite.com/docs/components/buttons/) 🙏 

###Recordings

https://github.com/social-plan-it/plan-it-social-web/assets/114109736/b8a80341-b916-4320-b018-29ee42ffc0d6

### Implementation details
As an example, some buttons can be found in /about-us. 

