### PR TITLE
adding unpic

### DIFF
--- a/app/components/marketing/hero-section.tsx
+++ b/app/components/marketing/hero-section.tsx
@@ -59,7 +59,14 @@ export default function HeroSection() {
           </Form>
         </div>
         <div className="w-4/5 mb-3 max-w-[600px] flex self-start">
-          <Image className="w-full" src="/imgs/Hero-Image.png" alt="group of people" height={379} width={553} />
+          <Image
+            className="w-full"
+            src="/imgs/Hero-Image.png"
+            alt="group of people"
+            height={379}
+            width={553}
+            priority
+          />
         </div>
       </div>
     </section>

--- a/app/components/marketing/hero-section.tsx
+++ b/app/components/marketing/hero-section.tsx
@@ -59,14 +59,7 @@ export default function HeroSection() {
           </Form>
         </div>
         <div className="w-4/5 mb-3 max-w-[600px] flex self-start">
-          <Image
-            className="w-full"
-            src="/imgs/Hero-Image.png"
-            alt="group of people"
-            height={379}
-            width={553}
-            priority
-          />
+          <Image className="w-full" src="/imgs/Hero-Image.png" alt="group of people" height={379} width={553} piority />
         </div>
       </div>
     </section>

--- a/app/components/marketing/hero-section.tsx
+++ b/app/components/marketing/hero-section.tsx
@@ -59,7 +59,7 @@ export default function HeroSection() {
           </Form>
         </div>
         <div className="w-4/5 mb-3 max-w-[600px] flex self-start">
-          <Image className="w-full" src="/imgs/Hero-Image.png" alt="group of people" />
+          <Image className="w-full" src="/imgs/Hero-Image.png" alt="group of people" height={379} width={553} />
         </div>
       </div>
     </section>

--- a/app/components/ui/images.tsx
+++ b/app/components/ui/images.tsx
@@ -6,6 +6,7 @@ type ImageProps = ImgHTMLAttributes<HTMLImageElement> & {
   src: string;
   width: number;
   height: number;
+  piority?: boolean;
 };
 
 export function Image({ ...props }: ImageProps) {

--- a/app/components/ui/images.tsx
+++ b/app/components/ui/images.tsx
@@ -1,10 +1,13 @@
 import type { ImgHTMLAttributes } from 'react';
+import { Image as UnpicImage } from '@unpic/react';
 
 type ImageProps = ImgHTMLAttributes<HTMLImageElement> & {
   alt: string;
   src: string;
+  width: number;
+  height: number;
 };
 
-export function Image({ alt, ...props }: ImageProps) {
-  return <img alt={alt} {...props} />;
+export function Image({ ...props }: ImageProps) {
+  return <UnpicImage {...props} />;
 }

--- a/app/routes/about-us.tsx
+++ b/app/routes/about-us.tsx
@@ -10,6 +10,8 @@ export default function AboutUs() {
             className="w-full"
             src="https://res.cloudinary.com/dxctpvd8v/image/upload/v1706807323/solar-system_pzkazh.png"
             alt="Solar system"
+            width={512}
+            height={512}
           />
         </div>
         <h2 className="w-50 pb-3 sm:w-100 font-bold sm:font-extrabold sm:text-4xl">
@@ -40,6 +42,8 @@ export default function AboutUs() {
             className="w-full"
             src="https://res.cloudinary.com/dxctpvd8v/image/upload/v1706805456/target_g3b96r.png"
             alt="Arrow in target"
+            width={512}
+            height={512}
           />
         </div>
         <div className="pb-3 w-full">
@@ -55,6 +59,8 @@ export default function AboutUs() {
             className="w-full"
             src="https://res.cloudinary.com/dxctpvd8v/image/upload/v1706806762/binoculars_vuhkgz.png"
             alt="Kid looking through binoculars"
+            width={512}
+            height={512}
           />
         </div>
         <div className="pb-3 w-full">
@@ -70,6 +76,8 @@ export default function AboutUs() {
             className="w-full"
             src="https://res.cloudinary.com/dxctpvd8v/image/upload/v1706806983/crowd_ld0rvy.png"
             alt="Diversity"
+            width={512}
+            height={512}
           />
         </div>
         <div className="pb-3 w-full">

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@prisma/client": "^5.1.1",
         "@remix-run/node": "2.1.0",
         "@remix-run/react": "2.1.0",
+        "@unpic/react": "^0.1.10",
         "bcryptjs": "^2.4.3",
         "clsx": "^2.0.0",
         "google-auth-library": "^9.0.0",
@@ -39,7 +40,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2409,6 +2410,32 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@unpic/core": {
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/@unpic/core/-/core-0.0.46.tgz",
+      "integrity": "sha512-geX6d87O4YKmr/JMeSqZjPEwhevhDLojef3R6mzy8hxUWMOP+IhaK+hKxFPGsaLEE/uvlw71MVAfW6EkAEqNxg==",
+      "dependencies": {
+        "unpic": "^3.17.0"
+      }
+    },
+    "node_modules/@unpic/react": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@unpic/react/-/react-0.1.10.tgz",
+      "integrity": "sha512-FQ8O2JxRm2aaR/uZkE6DlbXGdSYfFcO6y1v+SapqiT2thUSQKPp1Yy/8/1q80GAqoCrdgM/EJxdQBGo0jqDLtg==",
+      "dependencies": {
+        "@unpic/core": "0.0.46"
+      },
+      "peerDependencies": {
+        "next": ">=14",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vanilla-extract/babel-plugin-debug-ids": {
@@ -11710,6 +11737,11 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/unpic": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/unpic/-/unpic-3.17.0.tgz",
+      "integrity": "sha512-1b0ACPDLWqDE4MJ+IW5e48pGVSA5zKU2nF05EDxl/vvHq610MnfHNczIm6RBNPKuAA+G1tQ2ef1mgxj5J7+plw=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@prisma/client": "^5.1.1",
     "@remix-run/node": "2.1.0",
     "@remix-run/react": "2.1.0",
+    "@unpic/react": "^0.1.10",
     "bcryptjs": "^2.4.3",
     "clsx": "^2.0.0",
     "google-auth-library": "^9.0.0",


### PR DESCRIPTION
## Co-author
@shami-dev 

## Summary (1-2 sentences)

adding the capability of responsive images to our code base
this feature is only enabled on limited images for testing, will expand it once it's confirmed functioning

## Details (reason and description of the changes)

installed unpic
impimented in Image class under UI
edited all image that uses the class mentioned above

old image element:
![image](https://github.com/social-plan-it/plan-it-social-web/assets/29219684/37855113-127f-459c-a84c-5d02aed0eb38)

new image element:
![image](https://github.com/social-plan-it/plan-it-social-web/assets/29219684/91503e3d-92bf-41f8-90fc-da034b8b5217)

new image element with priority:
![image](https://github.com/social-plan-it/plan-it-social-web/assets/29219684/ecfe83cd-6763-45c7-bafd-875bfc702b10)

the functionality of conversion to webp cannot be verified before deployment


### Challenges (what problems did I face?) (optional)

kinda hard to verify functionality locally (because it optimize with CDN)


### Sources
https://unpic.pics/blog/responsive-images-on-remix/
