### PR TITLE
add skip to content button

### DIFF
--- a/app/components/layout/top-nav.tsx
+++ b/app/components/layout/top-nav.tsx
@@ -12,7 +12,7 @@ export function TopNav() {
 
   return (
     <nav className="bg-gray-800 p-4">
-      <a href="#main" className="sr-only focus:not-sr-only">
+      <a href="#main" className="sr-only focus:not-sr-only text-white">
         Skip to content
       </a>
       <div className="flex justify-start items-center max-w-screen-2xl mx-auto">

--- a/app/components/layout/top-nav.tsx
+++ b/app/components/layout/top-nav.tsx
@@ -12,6 +12,9 @@ export function TopNav() {
 
   return (
     <nav className="bg-gray-800 p-4">
+      <a href="#main" className="sr-only focus:not-sr-only">
+        Skip to content
+      </a>
       <div className="flex justify-start items-center max-w-screen-2xl mx-auto">
         <div className="text-white text-xl font-semibold flex justify-between items-center py-4 w-full">
           <Link to="/">

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -74,7 +74,7 @@ function Shell({ children }: { children: React.ReactNode }) {
       </head>
       <body className="min-h-screen w-full flex flex-col">
         <TopNav />
-        {children}
+        <section id="main">{children}</section>
         <ScrollRestoration />
         <Scripts />
         <LiveReload />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -74,7 +74,7 @@ function Shell({ children }: { children: React.ReactNode }) {
       </head>
       <body className="min-h-screen w-full flex flex-col">
         <TopNav />
-        <section id="main">{children}</section>
+        <main id="main">{children}</main>
         <ScrollRestoration />
         <Scripts />
         <LiveReload />


### PR DESCRIPTION
## Summary (1-2 sentences)

adding skip to content button for keyboard-only navigation

## Details (reason and description of the changes)

great for accessibility in-line with w3 Bypass Blocks guidelines

https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-skip.html

### Alternative implementations
downside of existing implementation additional page load is conducted, (also adds unnecessary entry to history, which makes back to last page more annoying)
 
reddit.com and linkedin.com have a way to not append `#main` into the URL, unable to reverse engineer what they did 

## Screenshots/Recordings (if applicable)
![image](https://github.com/social-plan-it/plan-it-social-web/assets/29219684/d3f35acd-c22c-4758-aed5-7f5159807048)
![image](https://github.com/social-plan-it/plan-it-social-web/assets/29219684/f754ab2a-88f9-48d7-80bb-f78ddeb58102)

