### PR TITLE
Events route resizes and spacing/jonathan

### DIFF
--- a/app/components/marketing/events-section.tsx
+++ b/app/components/marketing/events-section.tsx
@@ -7,10 +7,10 @@ interface ExtendedEvent extends Event {
 
 export function EventsSection({ events }: { events: ExtendedEvent[] }) {
   return (
-    <section className="bg-secondary">
-      <div className="sm:ml-24 pt-10 pb-20 space-y-3 ">
-        <h2 className="text-center sm:text-left sm:text-5xl text-4xl font-bold italic text-primary">Upcoming Events</h2>
-        <div className="flex flex-wrap gap-6 justify-center sm:justify-start">
+    <section className="bg-secondary pb-8">
+      <div className="mx-auto py-8 md:max-w-screen-xl">
+        <h2 className="text-center pb-8 sm:text-4xl text-4xl font-bold italic text-primary">Upcoming Events</h2>
+        <div className="flex flex-wrap gap-6 justify-center sm:place-content-center">
           <EventsCards events={events} />
         </div>
       </div>

--- a/app/components/marketing/events-section.tsx
+++ b/app/components/marketing/events-section.tsx
@@ -46,21 +46,28 @@ export function EventCard({ event, index }: { event: ExtendedEvent; index: numbe
 
   return (
     <Link to={to} unstable_viewTransition>
-      <div className="flex flex-col space-y-3 w-[350px] mx-6 sm:mx-0 max-w-md p-6 rounded-2xl bg-primary">
-        {event.imgUrl && event.imgAlt && (
+      <div className="flex flex-col space-y-3 w-64 md:h-96 md:w-72 mx-6 sm:mx-0 max-w-md p-6 rounded-2xl bg-primary hover:transform hover:scale-105 transition-transform duration-300 hover:border">
+        {event.imgUrl && event.imgAlt ? (
           <img
             className={`${index === 1 && 'sm:order-2 pt-8'}  w-full object-contain box-border`}
             src={event.imgUrl}
             alt={event.imgAlt}
             style={{ viewTransitionName: isTransitioning ? 'image-expand' : '' }}
           />
+        ) : (
+          <img
+            className={`${index === 1 && 'sm:order-2 pt-8'}  w-full object-contain box-border`}
+            src={'https://res.cloudinary.com/dxctpvd8v/image/upload/v1709188683/default-event-photo_bvdslj.png'}
+            alt={'Default animated event zoom meeting'}
+            style={{ viewTransitionName: isTransitioning ? 'image-expand' : '' }}
+          />
         )}
 
         <div>
-          <div className="text-lg sm:text-2xl font-bold text-white">{event.group.name}</div>
-          <h3 className="text-3xl sm:text-4xl font-bold text-white">{event.name}</h3>
-          <p className="text-lg sm:text-2xl text-white">{event.description}</p>
-          <div className="text-lg sm:text-2xl font-bold text-white">{formattedTime}</div>
+          <div className="font-bold text-white">{event.group.name}</div>
+          <h3 className="font-bold text-white">{event.name}</h3>
+          <p className="text-white">{event.description}</p>
+          <div className="font-bold text-white">{formattedTime}</div>
         </div>
       </div>
     </Link>

--- a/app/components/marketing/events-section.tsx
+++ b/app/components/marketing/events-section.tsx
@@ -28,6 +28,14 @@ export function EventsCards({ events }: { events: ExtendedEvent[] }) {
   );
 }
 
+function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  } else {
+    return text.substring(0, maxLength - 3) + '...';
+  }
+}
+
 export function EventCard({ event, index }: { event: ExtendedEvent; index: number }) {
   const date = event.date.toLocaleString('en-US', {
     weekday: 'short',
@@ -66,7 +74,7 @@ export function EventCard({ event, index }: { event: ExtendedEvent; index: numbe
         <div>
           <div className="font-bold text-white">{event.group.name}</div>
           <h3 className="font-bold text-white">{event.name}</h3>
-          <p className="text-white">{event.description}</p>
+          <p className="text-white">{truncateText(event.description, 50)}</p>
           <div className="font-bold text-white">{formattedTime}</div>
         </div>
       </div>

--- a/app/components/marketing/hero-section.tsx
+++ b/app/components/marketing/hero-section.tsx
@@ -4,8 +4,7 @@ import { Image } from '../ui/images';
 export default function HeroSection() {
   return (
     <section className="bg-secondary pt-10 pb-40">
-      <div className="mx-auto max-w-screen-xl flex flex-wrap-reverse justify-center"
-      >
+      <div className="mx-auto max-w-screen-xl flex flex-wrap-reverse justify-center">
         <div className="w-4/5 max-w-[45%] min-w-[270px]">
           <h1 className="text-gray-800 font-bold text-4xl pb-8 w-full">Social made easy, memories made forever</h1>
           <p className="text-gray-800 font-bold text-lg pb-8 w-full">

--- a/app/components/marketing/hero-section.tsx
+++ b/app/components/marketing/hero-section.tsx
@@ -4,7 +4,8 @@ import { Image } from '../ui/images';
 export default function HeroSection() {
   return (
     <section className="bg-secondary pt-10 pb-40">
-      <div className="mx-auto w-screen max-w-screen-xl flex flex-wrap-reverse space-x-10 justify-center">
+      <div className="mx-auto max-w-screen-xl flex flex-wrap-reverse justify-center"
+      >
         <div className="w-4/5 max-w-[45%] min-w-[270px]">
           <h1 className="text-gray-800 font-bold text-4xl pb-8 w-full">Social made easy, memories made forever</h1>
           <p className="text-gray-800 font-bold text-lg pb-8 w-full">
@@ -58,8 +59,15 @@ export default function HeroSection() {
             </div>
           </Form>
         </div>
-        <div className="w-4/5 mb-3 max-w-[600px] flex self-start">
-          <Image className="w-full" src="/imgs/Hero-Image.png" alt="group of people" height={379} width={553} piority />
+        <div className="mx-auto w-4/5 md:w-1/2">
+          <Image
+            className="w-full mx-auto"
+            src="/imgs/Hero-Image.png"
+            alt="group of people"
+            height={379}
+            width={553}
+            piority
+          />
         </div>
       </div>
     </section>

--- a/app/routes/events.tsx
+++ b/app/routes/events.tsx
@@ -5,11 +5,14 @@ export default function EventsPage() {
   const events = useEvents();
 
   return (
-    <div className="sm:p-16">
-      <h1 className="text-center sm:text-left sm:text-5xl text-4xl font-bold italic text-primary sm:p-8">
+    <div
+      style={{ border: 'red solid 2px' }}
+      className="flex flex-col p-8 justify-center items-center md:items-start m-auto md:max-w-screen-xl "
+    >
+      <h1 style={{ border: 'orange solid 2px' }} className="font-bold italic mb-4 text-primary md:text-3xl">
         Upcoming Events
       </h1>
-      <div className="grid grid-cols-[repeat(auto-fit,minmax(22rem,1fr))] gap-y-8">
+      <div className="flex flex-col md:flex-row flex-wrap gap-y-4 gap-x-2">
         {events?.map((event, index) => {
           return <EventCard key={event.id} event={event} index={index} />;
         })}

--- a/app/routes/events.tsx
+++ b/app/routes/events.tsx
@@ -5,13 +5,8 @@ export default function EventsPage() {
   const events = useEvents();
 
   return (
-    <div
-      style={{ border: 'red solid 2px' }}
-      className="flex flex-col p-8 justify-center items-center md:items-start m-auto md:max-w-screen-xl "
-    >
-      <h1 style={{ border: 'orange solid 2px' }} className="font-bold italic mb-4 text-primary md:text-3xl">
-        Upcoming Events
-      </h1>
+    <div className="flex flex-col p-8 justify-center items-center md:items-start m-auto md:max-w-screen-xl ">
+      <h1 className="font-bold italic mb-4 text-primary md:text-3xl">Upcoming Events</h1>
       <div className="flex flex-col md:flex-row flex-wrap gap-y-4 gap-x-2">
         {events?.map((event, index) => {
           return <EventCard key={event.id} event={event} index={index} />;


### PR DESCRIPTION

## Summary (1-2 sentences)
Modified sizes of event card to maintain consistent sizing. I also added a default event photo, truncated Event Description so the text doesn't over flow, and centered a couple divs in the Hero section. 
# After:
![localhost_3000_events (2)](https://github.com/social-plan-it/plan-it-social-web/assets/55357003/b4aee407-a08d-4335-a85d-4ac5810bab6e)
# Before: 
![localhost_3000_events](https://github.com/social-plan-it/plan-it-social-web/assets/55357003/e464761b-f9fb-40fe-a615-41b86976ac42)


# Does it work on mobile? Make sure to include mobile screenshots or recordings!
![localhost_3000_events(Galaxy Fold)](https://github.com/social-plan-it/plan-it-social-web/assets/55357003/3724ccba-46d5-45d2-9c5d-e29eb10c608f)

