### PR TITLE
added a column for photo credits in the footer section

### DIFF
--- a/app/components/layout/footer.tsx
+++ b/app/components/layout/footer.tsx
@@ -101,12 +101,25 @@ export default function Footer() {
               </a>
             </li>
           </ul>
+          <ul className="mb-8">
+            <li className="text-lg">Photo Credits</li>
+            <li className="pb-1">
+              <a className="text-gray-400  font-thin" target="_blank" href="https://www.flaticon.com" rel="noreferrer">
+                Flaticon.com
+              </a>
+            </li>
+            <li className="pb-1">
+              <a className="text-gray-400  font-thin" target="_blank" href="https://www.pexels.com" rel="noreferrer">
+                Pexels.com
+              </a>
+            </li>
+          </ul>
         </div>
         <img className="sm:hidden ml-8 pt-4" src={VercelBanner} alt="Vercel Banner" />
         {/*Bottom Links*/}
         <div className="mx-8  pt-20    ">
           <ul className="flex flex-col justify-center  sm:flex-row   sm:space-x-8">
-            <li className="mb-4 ml-8">@ 2023 Social Plan-it</li>
+            <li className="mb-4 ml-8">@ 2024 Social Plan-it</li>
             <li className="mb-4 ml-8">
               <a href="/">Terms of Service</a>
             </li>


### PR DESCRIPTION

Issue: #<Number>
#94 

# Summary (1-2 sentences)
### Added a column in the Footer component for Photo Credits
### Provided links to Flaticon.com and Pexels.com
#
# Screenshots:
![image](https://github.com/social-plan-it/plan-it-social-web/assets/55357003/ef0b7740-e974-4d88-952e-f4e3c61dfd73)
#
# Is it responsive:
## Yes
![image](https://github.com/social-plan-it/plan-it-social-web/assets/55357003/e92fb2c5-f10b-4e69-8d7c-13e35d184331)

