### PR TITLE
patch top nav menu still showing after screen size change

### DIFF
--- a/app/components/layout/top-nav.tsx
+++ b/app/components/layout/top-nav.tsx
@@ -72,7 +72,7 @@ export function TopNav() {
         </button>
       </div>
       {isMenuOpen && (
-        <div className="mt-4">
+        <div className="mt-4 md:hidden">
           <Link className="block text-white py-2 px-4 hover:bg-gray-700" to="/">
             Home
           </Link>


### PR DESCRIPTION
### Thanks for joining the Sunday Session:
@kwesibatchelor 
@willbeaumont 

Issue: #<Number>

https://github.com/social-plan-it/plan-it-social-web/issues/107

## Summary (1-2 sentences)

patch the issue where top-nav menu still showing when display goes bigger


### Alternative implementations (what alternatives were considered and why were they disregarded?) (optional)

can use Headless UI for it


## Screenshots/Recordings (if applicable)

https://github.com/social-plan-it/plan-it-social-web/assets/29219684/b93c5fce-aede-41ab-bfe9-2fd01b36faef
