### PR TITLE
edited prisma for supabase

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,9 @@ generator client {
 }
 
 datasource db {
-  provider     = "mysql"
-  url          = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
   relationMode = "prisma"
 }
 


### PR DESCRIPTION
## Summary (1-2 sentences)

Patch up deployment error cause by DB migration to supabase

- (non code) changed env variable of DB URL in Github env
- changed DB from MySQL to PostgreSQL in Prisma schema

## Screenshots/Recordings (if applicable)

new deployment preview:

https://plan-it-social-hj9ca7ttl-allthingsweb.vercel.app/

![image](https://github.com/social-plan-it/plan-it-social-web/assets/29219684/d9b4c158-e164-415c-a160-a6d9ae655c12)


