### PR TITLE
Migrate database to Supabase

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,8 +6,9 @@ generator client {
 }
 
 datasource db {
-  provider     = "mysql"
+  provider     = "postgresql"
   url          = env("DATABASE_URL")
+  directUrl    = env("DIRECT_URL")
   relationMode = "prisma"
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -76,6 +76,7 @@ const groups = [
 ];
 
 async function seed() {
+  console.log('Seeding data...');
   try {
     for (const user of users) {
       await db.user.create({
@@ -112,4 +113,4 @@ async function seed() {
   }
 }
 
-seed();
+await seed();


### PR DESCRIPTION
## Summary (1-2 sentences)

PR to migrate database to Supabase

## Details (reason and description of the changes)

PlanetScale removed its free tier. This PR updates the Prisma schema for our migration to Supabase (Postgres).

### Implementation details (how was this change implemented?) (optional)

- Updates Prisma schema to run on Postgres
- Adds new `DIRECT_URL` environment variable (as suggested by Supabase, [see Prisma docs for more info](https://www.prisma.io/docs/orm/reference/prisma-schema-reference))
