### PR TITLE
added meta exports to groups, about-us, and events routes

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -6,7 +6,13 @@ import { EventsSection } from '../components/marketing/events-section';
 import { BenefitsSection } from '~/components/marketing/benefits-section';
 
 export const meta: MetaFunction = () => {
-  return [{ title: 'Home' }];
+  return [
+    { title: 'Home | Social Plan-It' },
+    {
+      name: 'description',
+      content: 'Social Plan-It is where you can join groups and events to collaborate to learn and meet new friends.',
+    },
+  ];
 };
 
 export async function loader() {

--- a/app/routes/about-us.tsx
+++ b/app/routes/about-us.tsx
@@ -1,3 +1,4 @@
+import type { MetaFunction } from '@remix-run/node';
 import { Image } from '~/components/ui/images';
 
 export default function AboutUs() {
@@ -87,3 +88,10 @@ export default function AboutUs() {
     </div>
   );
 }
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: 'About | Social Plan-It' },
+    { name: 'description', content: 'Checkout what Social Plan-It is all about' },
+  ];
+};

--- a/app/routes/events.tsx
+++ b/app/routes/events.tsx
@@ -1,3 +1,4 @@
+import type { MetaFunction } from '@remix-run/node';
 import { useEvents } from '~/hooks/useEvents';
 import { EventCard } from '~/components/marketing/events-section';
 
@@ -15,3 +16,10 @@ export default function EventsPage() {
     </div>
   );
 }
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: 'Events | Social Plan-It' },
+    { name: 'description', content: 'Your welcome to join us in any event. Looking forward to seeing you there!' },
+  ];
+};

--- a/app/routes/groups.tsx
+++ b/app/routes/groups.tsx
@@ -2,7 +2,7 @@ import { Form, Link, useLoaderData } from '@remix-run/react';
 import { Image } from '~/components/ui/images';
 import { LinkButton } from '~/components/ui/forms';
 import { db } from '~/modules/database/db.server';
-import { type LoaderFunctionArgs } from '@remix-run/node';
+import type { MetaFunction, LoaderFunctionArgs } from '@remix-run/node';
 import type { Group } from '@prisma/client';
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -92,3 +92,10 @@ export default function Group() {
     </div>
   );
 }
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: 'Groups | Social Plan-It' },
+    { name: 'description', content: "We have an array of groups you'd love. Come join a group!" },
+  ];
+};


### PR DESCRIPTION
## Summary (1-2 sentences)
### Added meta exports to the groups, about-us, and events routes to include titles and meta descriptions, enhancing SEO.

### Had trouble with typecheck when adding a dynamic meta export in events_$eventId. Working on this with #163 

![image](https://github.com/social-plan-it/plan-it-social-web/assets/55357003/022f562f-480a-43ce-9389-c8e7ad03e696)

## Before:
![image](https://github.com/social-plan-it/plan-it-social-web/assets/55357003/eb97bf70-ad4c-4f15-acc4-b047a4855e5c)

## After: 
### SEO improves to 100
![image](https://github.com/social-plan-it/plan-it-social-web/assets/55357003/abca025c-d225-4242-bc94-4dc88360b04c)

